### PR TITLE
Split command before running

### DIFF
--- a/GUI/src/ImpactMainWindow.py
+++ b/GUI/src/ImpactMainWindow.py
@@ -944,6 +944,7 @@ class ImpactMainWindow(tk.Tk):
             elif np>1:
                 cmd = self.MPI_EXE.get()+' -n '+str(np)+' '+ImpactExe
             print(cmd)
+            cmd = cmd.split()
             p=subprocess.Popen(cmd,stdout=subprocess.PIPE,bufsize=1)
             for line in iter(p.stdout.readline,b''):
                 print(('>>{}'.format(line.rstrip())))
@@ -963,6 +964,7 @@ class ImpactMainWindow(tk.Tk):
             elif np>1:
                 cmd = self.MPI_EXE.get()+' -n '+str(np)+' '+ImpactExe
             print(cmd)
+            cmd = cmd.split()
             p=subprocess.Popen(cmd,stdout=subprocess.PIPE,bufsize=1)
             for line in iter(p.stdout.readline,b''):
                 print(('>>{}'.format(line.rstrip())))


### PR DESCRIPTION
This fix is designed to avoid the following error that comes up when clicking the 'Run' button in the GUI:

```
FileNotFoundError: [Errno 2] No such file or directory: 'mpirun -n 4 /path/to/ImpactTexe'
```

This may again be due to different versions of libraries, in this case the _Python_ `subprocess` library.

The fix is just to split the command before trying to run it. Then the first part is just `mpirun`, which the input check can find OK.