### PR TITLE
Add absolute source path rather than relative

### DIFF
--- a/GUI/ImpactGUI.py
+++ b/GUI/ImpactGUI.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3 
 
 import sys; 
-if not "./src/" in sys.path:
-    sys.path.append("./src/") 
+import pathlib;
+
+src_path = pathlib.Path(__file__).parent.joinpath("src").absolute().as_posix()
+if not src_path in sys.path:
+    sys.path.append(src_path)
 if not 'ImpactMainWindow' in sys.modules:
     ImpactMainWindow = __import__('ImpactMainWindow')
 else:


### PR DESCRIPTION
Previously, if this script is called from anywhere outside the current directory, it would fail. This is because it adds a relative path `"./src/"` rather than the actual path of the source scripts.

This change uses the path manipulation module `pathlib` and **should** be cross-platform compatible. However, I don't currently have access to a _Windows_ machine for testing, so this pull request should be tested well on all systems before being merged.

I've used the `as_posix()` method to get the final string, which I think is correct for _Python_ paths on all systems. If it doesn't work properly on _Windows_, it may need to use the `str()` function instead, like this:

```python
src_path = str(pathlib.Path(__file__).parent.joinpath("src").absolute())
```

The code first gets the full path of the currently running script (`__file__`, which is `/path/to/IMPACT-T/GUI/ImpactGUI.py`), then gets the parent (`/path/to/IMPACT-T/GUI`), then joins the subfolder `src` on the end to get `/path/to/IMPACT-T/GUI/src`, then checks that the path is absolute before converting to a POSIX path string (using `.as_posix()`) or converting to a more general string (using `str()`).