### PR TITLE
Skip space-charge calculation on empty or neutral bunches

### DIFF
--- a/src/Contrl/AccSimulator.f90
+++ b/src/Contrl/AccSimulator.f90
@@ -1808,6 +1808,10 @@
            
             !//sum up the space-charge fields from all bunches/bins
             do ib = 1, ibunch
+
+              ! Skip any empty or neutral bunches
+              IF ((Np(ib) == 0) .OR. (Ebunch(ib)%Charge < 0.1d-10)) CYCLE
+
               ! deposit particles onto grid to obtain charge density of each bunch/bin.
               if(flagazmuth.eq.1) then
                 call chgdenstest_Depositor(Ebunch(ib),chgdens,Ageom,grid2d,&

--- a/src/Contrl/AccSimulator.f90
+++ b/src/Contrl/AccSimulator.f90
@@ -1810,7 +1810,7 @@
             do ib = 1, ibunch
 
               ! Skip any empty or neutral bunches
-              IF ((Np(ib) == 0) .OR. (Ebunch(ib)%Charge < 0.1d-10)) CYCLE
+              IF ((Np(ib) == 0) .OR. (ABS(Ebunch(ib)%Charge) < 0.1d-10)) CYCLE
 
               ! deposit particles onto grid to obtain charge density of each bunch/bin.
               if(flagazmuth.eq.1) then


### PR DESCRIPTION
Avoids divide-by-zero errors when one of the bunches is empty or neutral.

This can happen with a wide energy spread, where some outlying bunches have low particle numbers.
This can also happen with interaction bunches, when particle interactions mean there are no particles of a particular type at some points.
This can also happen when the simulation includes neutral particles.