### PR TITLE
Fix GUI plotting code for newer versions of Matplotlib

### DIFF
--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -377,10 +377,10 @@ class PlotFrame(tk.Frame):
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
         
         fig = Figure(figsize=(7,5), dpi=100)
-        subfig = fig.add_subplot(111)
-        subfig.plot(x,y)
-        subfig.set_xlabel('Z (m)')
-        subfig.set_ylabel(labelY)
+        self.subfig = fig.add_subplot(111)
+        self.subfig.plot(x,y)
+        self.subfig.set_xlabel('Z (m)')
+        self.subfig.set_ylabel(labelY)
 
         xMax = np.max(x)
         xMin = np.min(x)
@@ -393,8 +393,8 @@ class PlotFrame(tk.Frame):
         
         #xmajorFormatter = FormatStrFormatter('%2.2E')
         #subfig.yaxis.set_major_formatter(xmajorFormatter)
-        box = subfig.get_position()
-        subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self)
         canvas.draw()
@@ -723,6 +723,6 @@ def axis_format_T(xData,yData,subfig):
     yMax = np.max(yData)
     yMin = np.min(yData)
     if (xMax-xMin)>IMPACT_T_sciMaxLimit or (xMax-xMin)<IMPACT_T_sciMinLimit:
-        subfig.xaxis.set_major_formatter(IMPACT_T_SciFormatter)
+        self.subfig.xaxis.set_major_formatter(IMPACT_T_SciFormatter)
     if (yMax-yMin)>IMPACT_T_sciMaxLimit or (yMax-yMin)<IMPACT_T_sciMinLimit:
-        subfig.yaxis.set_major_formatter(IMPACT_T_SciFormatter)
+        self.subfig.yaxis.set_major_formatter(IMPACT_T_SciFormatter)

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import ttk,filedialog
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 from scipy.stats import gaussian_kde
@@ -344,7 +344,7 @@ class PlotBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -400,7 +400,7 @@ class PlotFrame(tk.Frame):
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        toolbar = NavigationToolbar2TkAgg(canvas, self)
+        toolbar = NavigationToolbar2Tk(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     
@@ -422,7 +422,7 @@ class OverallFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -652,7 +652,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -341,7 +341,7 @@ class PlotBaseFrame(tk.Frame):
         self.subfig = self.fig.add_subplot(111)
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -397,7 +397,7 @@ class PlotFrame(tk.Frame):
         subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self)
-        canvas.show()
+        canvas.draw()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2Tk(canvas, self)
@@ -419,7 +419,7 @@ class OverallFrame(tk.Frame):
         self.subfig.append(self.fig.add_subplot(224))
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -649,7 +649,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import ttk,filedialog
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 
@@ -320,7 +320,7 @@ class PlotBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -374,7 +374,7 @@ class PlotFrame(tk.Frame):
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        toolbar = NavigationToolbar2TkAgg(canvas, self)
+        toolbar = NavigationToolbar2Tk(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     
@@ -396,7 +396,7 @@ class OverallFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -621,7 +621,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -317,7 +317,7 @@ class PlotBaseFrame(tk.Frame):
         self.subfig = self.fig.add_subplot(111)
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -371,7 +371,7 @@ class PlotFrame(tk.Frame):
         subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
-        canvas.show()
+        canvas.draw()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2Tk(canvas, self)
@@ -393,7 +393,7 @@ class OverallFrame(tk.Frame):
         self.subfig.append(self.fig.add_subplot(224))
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -618,7 +618,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -352,10 +352,10 @@ class PlotFrame(tk.Frame):
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
         
         fig = Figure(figsize=(7,5), dpi=100)
-        subfig = fig.add_subplot(111)
-        subfig.plot(x,y)
-        subfig.set_xlabel('Z (m)')
-        subfig.set_ylabel(labelY)
+        self.subfig = fig.add_subplot(111)
+        self.subfig.plot(x,y)
+        self.subfig.set_xlabel('Z (m)')
+        self.subfig.set_ylabel(labelY)
         
         
         xMax = np.max(x)
@@ -367,8 +367,8 @@ class PlotFrame(tk.Frame):
         if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
         
-        box = subfig.get_position()
-        subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
         canvas.draw()
@@ -677,6 +677,6 @@ def axis_format_Z(xData,yData,subfig):
     yMax = np.max(yData)
     yMin = np.min(yData)
     if (xMax-xMin)>IMPACT_Z_sciMaxLimit or (xMax-xMin)<IMPACT_Z_sciMinLimit:
-        subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
     if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
-        subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -318,7 +318,7 @@ class PlotBaseFrame(tk.Frame):
         self.subfig = self.fig.add_subplot(111)
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -372,7 +372,7 @@ class PlotFrame(tk.Frame):
         subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
-        canvas.show()
+        canvas.draw()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2Tk(canvas, self)
@@ -394,7 +394,7 @@ class OverallFrame(tk.Frame):
         self.subfig.append(self.fig.add_subplot(224))
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -619,7 +619,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import ttk,filedialog
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 
@@ -321,7 +321,7 @@ class PlotBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -375,7 +375,7 @@ class PlotFrame(tk.Frame):
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        toolbar = NavigationToolbar2TkAgg(canvas, self)
+        toolbar = NavigationToolbar2Tk(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     
@@ -397,7 +397,7 @@ class OverallFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -622,7 +622,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -353,10 +353,10 @@ class PlotFrame(tk.Frame):
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
         
         fig = Figure(figsize=(7,5), dpi=100)
-        subfig = fig.add_subplot(111)
-        subfig.plot(x,y)
-        subfig.set_xlabel('Z (m)')
-        subfig.set_ylabel(labelY)
+        self.subfig = fig.add_subplot(111)
+        self.subfig.plot(x,y)
+        self.subfig.set_xlabel('Z (m)')
+        self.subfig.set_ylabel(labelY)
         
         
         xMax = np.max(x)
@@ -368,8 +368,8 @@ class PlotFrame(tk.Frame):
         if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
         
-        box = subfig.get_position()
-        subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
         canvas.draw()
@@ -678,6 +678,6 @@ def axis_format_Z(xData,yData,subfig):
     yMax = np.max(yData)
     yMin = np.min(yData)
     if (xMax-xMin)>IMPACT_Z_sciMaxLimit or (xMax-xMin)<IMPACT_Z_sciMinLimit:
-        subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
     if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
-        subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)

--- a/GUI/src/ParticlePlot.py
+++ b/GUI/src/ParticlePlot.py
@@ -147,7 +147,7 @@ class ParticleBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
         
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ParticlePlot.py
+++ b/GUI/src/ParticlePlot.py
@@ -5,7 +5,7 @@ import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 from scipy.stats import gaussian_kde
@@ -150,7 +150,7 @@ class ParticleBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/SlicePlot.py
+++ b/GUI/src/SlicePlot.py
@@ -77,7 +77,7 @@ class SliceBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
         
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/SlicePlot.py
+++ b/GUI/src/SlicePlot.py
@@ -6,7 +6,7 @@ matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 
@@ -80,7 +80,7 @@ class SliceBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         


### PR DESCRIPTION
Renamed and rebased version of pull request #2.

I've made some small changes to the plotting code in the GUI, because it was incompatible with the version of Matplotlib on my computer (3.0.2-2).

In version 3.0.0, Matplotlib dropped support for the deprecated class NavigationToolbar2TkAgg and for the deprecated show() method of the FigureCanvasTkAgg class. I've replaced these with the recommended replacements.

I also had problems where some plots didn't plot at all, saying: `AttributeError: 'PlotFrame' object has no attribute 'subfig’.` This seems to be because `subfig` and `self.subfig` were not used consistently.