### PR TITLE
Multi-bunch plotting capabilities

### DIFF
--- a/GUI/ImpactGUI.py
+++ b/GUI/ImpactGUI.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3 
 
-import sys; 
+import sys;
 if not "./src/" in sys.path:
-    sys.path.append("./src/") 
+    sys.path.append("./src/")
 if not 'ImpactMainWindow' in sys.modules:
     ImpactMainWindow = __import__('ImpactMainWindow')
 else:
     eval('import ImpactMainWindow')
-    ImpactMainWindow = eval('reload(ImpactMainWindow)') 
+    ImpactMainWindow = eval('reload(ImpactMainWindow)')
 
 root = ImpactMainWindow.ImpactMainWindow()
 ImpactMainWindow.MyMenu(root)

--- a/GUI/Readme.txt
+++ b/GUI/Readme.txt
@@ -1,6 +1,6 @@
 ImpactGUI is a python GUI for the ImpactT and ImpactZ codes.
 It can be used on Windows, MAC and Linux/Unix systems.
-To use the ImpactGUI, one needs to install 
+To use the ImpactGUI, one needs to install
 Pyhon3 Tkinter, Numpy, Scipy and Matplotlib.
 To run the Impact code under the GUI, one can either put the executables
 of ImpactT (ImpactTexe) and ImpactZ (ImpactZexe) under the

--- a/GUI/help/ImpactZv1Readme3.txt
+++ b/GUI/help/ImpactZv1Readme3.txt
@@ -1,31 +1,31 @@
 ******************* Copyright Notice ********************************
-IMPACT-Z  v 1.7 Copyright (c) 2012, The Regents of the University of 
-California, through Lawrence Berkeley National Laboratory (subject to 
-receipt of any required approvals from the U.S. Dept. of Energy).  
+IMPACT-Z  v 1.7 Copyright (c) 2012, The Regents of the University of
+California, through Lawrence Berkeley National Laboratory (subject to
+receipt of any required approvals from the U.S. Dept. of Energy).
 All rights reserved.
 
-If you have questions about your rights to use or distribute this 
-software, please contact Berkeley Lab's Technology Transfer Department 
+If you have questions about your rights to use or distribute this
+software, please contact Berkeley Lab's Technology Transfer Department
 at  TTD@lbl.gov .
 
-NOTICE.  This software was developed under partial funding from the U.S. 
-Department of Energy.  As such, the U.S. Government has been granted for 
+NOTICE.  This software was developed under partial funding from the U.S.
+Department of Energy.  As such, the U.S. Government has been granted for
 itself and others acting on its behalf a paid-up, nonexclusive, irrevocable,
-worldwide license in the Software to reproduce, prepare derivative works, 
-and perform publicly and display publicly.  Beginning five (5) years after 
-the date permission to assert copyright is obtained from the U.S. 
-Department of Energy, and subject to any subsequent five (5) year 
-renewals, the U.S. Government is granted for itself and others acting 
-on its behalf a paid-up, nonexclusive, irrevocable, worldwide license 
-in the Software to reproduce, prepare derivative works, distribute 
-copies to the public, perform publicly and display publicly, and to 
+worldwide license in the Software to reproduce, prepare derivative works,
+and perform publicly and display publicly.  Beginning five (5) years after
+the date permission to assert copyright is obtained from the U.S.
+Department of Energy, and subject to any subsequent five (5) year
+renewals, the U.S. Government is granted for itself and others acting
+on its behalf a paid-up, nonexclusive, irrevocable, worldwide license
+in the Software to reproduce, prepare derivative works, distribute
+copies to the public, perform publicly and display publicly, and to
 permit others to do so.
 
 ******************** End of Copyright Notice****************************
 ------------
 AUTHORS
 ------------
-Ji Qiang, Rober D. Ryne 
+Ji Qiang, Rober D. Ryne
 Ms 71 J, ATAP
 1 cyclotron Rd.
 Lawrence Berkeley National Laboratory
@@ -39,12 +39,12 @@ CONTRIBUTORS
 ------------
 INTRODUCTION
 ------------
-IMPACT-Z is a 3D parallel/serial Particle-In-Cell (PIC) code based on 
+IMPACT-Z is a 3D parallel/serial Particle-In-Cell (PIC) code based on
 multi-layer object-oriented design.
 The present version of IMPACT-Z can treat intense beams propagating
 through drifts, magnetic quadrupoles, magnetic soleniods, and rf cavities
 using linear map integrator and drifts, magnetic dipoles, quadrupoles,
-soleniods, and rf cavities using nonlinear Lorentz integrator. 
+soleniods, and rf cavities using nonlinear Lorentz integrator.
 It has a novel treatment of rf cavities, in which the gap transfer maps
 are computed during the simulations by reading in Superfish rf fields.
 The goal is to avoid time-consuming (and unnecessary) fine-scale
@@ -53,30 +53,30 @@ cavity fields. Instead, fine-scale integration is used to compute the
 maps (which involve a small number of terms), and the maps are applied
 to particles. If you are familiar with magnetic optics, then you will
 recognize that this is analogous to the technique used to simulate
-beam transport through magnets with fringe fields. 
+beam transport through magnets with fringe fields.
 
 The version of IMPACT-Z currently
 has a 3D space-charge model that assumes several types of
-boundary conditions: 1) 3D open boundary conditions, 
+boundary conditions: 1) 3D open boundary conditions,
 2) a solver that uses open boundary conditions transversely and
 periodic boundary conditions longitudinally, and 3) solvers for
 round and rectangular conducting pipes (where the longitudinal
 boundary condition is either open or periodic).
 It does not include the calculation of CSR wakefield through
-the bending magnet since this version is primary used for 
+the bending magnet since this version is primary used for
 modeling the mult-charge state ion beams.
 The error studies can include the field errors, misalignment
-errors, and rotation errors. 
+errors, and rotation errors.
 ---------------------------------------------------
 
-To run the IMPACTz code on Windows PC, one needs to open a 
+To run the IMPACTz code on Windows PC, one needs to open a
 DOS window using the "cmd" command. Then, one needs to type in
 the ImpactTz executable name to run the code. All input files should be
 under the same directory as the IMPACT executable code.
 
 To run the IMPACTz code, the user needs to prepare some input files.
 Note: when download those files from the web, make sure that there
-is NO extra file extension that is automatically added to the file. 
+is NO extra file extension that is automatically added to the file.
 
 -----------
 There are a few utility programs under:
@@ -124,24 +124,24 @@ Also, any line starting with ! will be treated as a comment line.
 6 10000000 1 0 1        (6D problem with 10M particles, "1" for linear map
                          integrator ("2" for nonlinear Lorentz integrator),
                          "0" for no error studies ("1" for error studies),
-                         "1" for standard output ("2" for 90%, 95%, 99% 
+                         "1" for standard output ("2" for 90%, 95%, 99%
                          emittance, radius output).)
 64 64 64 1 0.014 0.014 0.10  (64x64x64 space-charge grid, "1" for 3D open
                              all mesh numbers have to a power of 2, i.e. 2^n;
                              "2" for transverse open, longitudinal periodic,
                              (the 3rd mesh number has to 2^n+1)
-                             "3" for transverse finite, longitudinal open 
+                             "3" for transverse finite, longitudinal open
                              round pipe (in this case, the 2nd mesh number has
-                             to be 2^n+1), "4" for transverse finite, 
+                             to be 2^n+1), "4" for transverse finite,
                              longitudinal periodic round pipe (in this case,
                              the 2nd and the 3rd mesh number has to be
-                             2^n+1), "5" for 
+                             2^n+1), "5" for
                              transverse finite, longitudinal open rectangular
                              pipe (in this case, the 1st and the 2nd mesh
                              number have to be 2^n+1),"6" for transverse finite,
-                             longitudinal periodic rectangular pipe (in this 
-                             case, all mesh number have to be 2^n+1)), 
-                             x pipe width 
+                             longitudinal periodic rectangular pipe (in this
+                             case, all mesh number have to be 2^n+1)),
+                             x pipe width
                              "0.014" m, y pipe width "0.014" m, period length
                              "0.10" m.
 3 0 0 4                 (Input distribution is "type 3",
@@ -157,7 +157,7 @@ Also, any line starting with ! will be treated as a comment line.
                         [this is
                         undergoing tests in Testing directory. More later.])
                         "0" means no restart ("1" means to restart from
-                        some point after stop), "0" means no sub-cycle 
+                        some point after stop), "0" means no sub-cycle
                         ("1" means sub-cycle).
                         "4" for # of charge states = 4.
 16000 16000 16000 16000 (# of particle list for each charge state)
@@ -207,10 +207,10 @@ Also, any line starting with ! will be treated as a comment line.
                                             misalignment error=0.0m, rotation
                                             error x, y, z = 0.0, 0., 0. rad.)
 !
-0.30      4  20    2  9.8696 9.8696 9.8696 0.014 / (3D constant focusing, 
+0.30      4  20    2  9.8696 9.8696 9.8696 0.014 / (3D constant focusing,
                                             length=0.3m, 4 "steps",
                    ^                        " 20 "map steps",kx0^2=9.8696,
-                 constant focusing          ky0^2=9.8696,kz0^2=9.8696, 
+                 constant focusing          ky0^2=9.8696,kz0^2=9.8696,
                                             radius=0.014m. Note, it does not work
                                             for Lorentz integrator option.)
 !
@@ -223,81 +223,81 @@ Also, any line starting with ! will be treated as a comment line.
                                             error x, y, z=0.0, 0., 0. rad.
                                             Note: the map integrator only
                                             works for v1.7 and later.
-                                            For the Lorentz integrator, the 
+                                            For the Lorentz integrator, the
                                             length includes two linear fringe regions
                                             and a flat top region. Here, the
                                             length of the fringe region is
-                                            defined by the 2*radius. 
+                                            defined by the 2*radius.
                                             The total length = effective length +
                                             2*radius.)
 !
 1.48524   10 20   4   0.1  0.0  150.  0.014  0.0 0.0 0.0 0. 0. /
                   ^                  (magnetic dipole, length=1.48524m,
                 dipole               10 "steps", 20 "map steps"
-                                     bending angle 0.1rad, k1=0.0, input 
-                                     switch 150., radius=0.014m,0.0=entr. 
+                                     bending angle 0.1rad, k1=0.0, input
+                                     switch 150., radius=0.014m,0.0=entr.
                                      pole face angle(rad),
-                                     0.0=exit pole face angle, 0.0=curvature of         
+                                     0.0=exit pole face angle, 0.0=curvature of
                                      entr. face, 0.0=curv. Of exit face,
-                                     0.0=integrated fringe field. 
+                                     0.0=integrated fringe field.
 !
 1.48524   10 20   101   1.0 700.0e6 30. 1.0 0.014 0.01 1.0 0.01 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 /
                   ^              (RF cavity, length=1.48524m,
                  DTL             10 "steps", 20 "map steps"
                                  field scaling=1.0, RF frequency=700.0e6,
-                                 driven phase=30.0 degree, input field 
+                                 driven phase=30.0 degree, input field
                                  ID=1.0, radius=0.014m, quad 1 length=0.01m,
                                  quad 1 gradient=1.0T/m, quad 2 length=0.01m,
-                                 quad 2 gradient, x misalignment 
-                                 error=0.0m, y misalignment error=0.0m, 
+                                 quad 2 gradient, x misalignment
+                                 error=0.0m, y misalignment error=0.0m,
                                  rotation error x, y, z=0.0, 0., 0. rad for
-                                 quad, x displacement, y displacement, 
+                                 quad, x displacement, y displacement,
                                  rotation error x, y, z for RF field.
 !
 1.48524   10 20   102   1.0 700.0e6 30. 1.0 0.014 0. 0. 0. 0. 0. /
                   ^              (RF cavity, length=1.48524m,
                  CCDTL             10 "steps", 20 "map steps"
                                  field scaling=1.0, RF frequency=700.0e6,
-                                 driven phase=30.0 degree, input field 
-                                 ID=1.0, radius=0.014m, x misalignment 
-                                 error=0.0m, y misalignment error=0.0m, 
+                                 driven phase=30.0 degree, input field
+                                 ID=1.0, radius=0.014m, x misalignment
+                                 error=0.0m, y misalignment error=0.0m,
                                  rotation error x, y, z=0.0, 0., 0. rad)
 !
 1.48524   10 20   103   1.0 700.0e6 30. 1.0 0.014 0. 0. 0. 0. 0. /
                   ^              (RF cavity, length=1.48524m,
                  CCL             10 "steps", 20 "map steps"
                                  field scaling=1.0, RF frequency=700.0e6,
-                                 driven phase=30.0 degree, input field 
-                                 ID=1.0, radius=0.014m, x misalignment 
-                                 error=0.0m, y misalignment error=0.0m, 
+                                 driven phase=30.0 degree, input field
+                                 ID=1.0, radius=0.014m, x misalignment
+                                 error=0.0m, y misalignment error=0.0m,
                                  rotation error x, y, z=0.0, 0., 0. rad)
 !
 1.48524   10 20   104   1.0 700.0e6 30. 1.0 0.014 0. 0. 0. 0. 0. /
                   ^              (RF cavity, length=1.48524m,
                   SC             10 "steps", 20 "map steps"
                                  field scaling=1.0, RF frequency=700.0e6,
-                                 driven phase=30.0 degree, input field 
-                                 ID=1.0, radius=0.014m, x misalignment 
-                                 error=0.0m, y misalignment error=0.0m, 
+                                 driven phase=30.0 degree, input field
+                                 ID=1.0, radius=0.014m, x misalignment
+                                 error=0.0m, y misalignment error=0.0m,
                                  rotation error x, y, z=0.0, 0., 0. rad)
 !
 1.48524   10 20   105   1.0 700.0e6 30. 1.0 0.014 0. 0. 0. 0. 0. 1.0 /
                   ^              (Solenoid with RF cavity, length=1.48524m,
                   SolRF           10 "steps", 20 "map steps"
                                  field scaling=1.0, RF frequency=700.0e6,
-                                 driven phase=30.0 degree, input field 
-                                 ID=1.0, radius=0.014m, x misalignment 
-                                 error=0.0m, y misalignment error=0.0m, 
-                                 rotation error x, y, z=0.0, 0., 0. rad, 
+                                 driven phase=30.0 degree, input field
+                                 ID=1.0, radius=0.014m, x misalignment
+                                 error=0.0m, y misalignment error=0.0m,
+                                 rotation error x, y, z=0.0, 0., 0. rad,
                                  Bz0=1.0 Tesla)
 !
 1.48524   10 20   110   1.0 700.0e6 30. 1.0 0.014 0.014 0. 0. 0. 0. 0. 1.0 1.0 /
                   ^              (user defined RF cavity, length=1.48524m,
                   EMfld          10 "steps", 20 "map steps"
                                  field scaling=1.0, RF frequency=700.0e6,
-                                 driven phase=30.0 degree, input field 
-                                 ID=1.0, radius=0.014m, x misalignment 
-                                 error=0.0m, y misalignment error=0.0m, 
+                                 driven phase=30.0 degree, input field
+                                 ID=1.0, radius=0.014m, x misalignment
+                                 error=0.0m, y misalignment error=0.0m,
                                  rotation error x, y, z=0.0, 0., 0. rad),
                                  1.0 (using discrete data only, 2.0 using both
                                  discrete data and analytical function, other
@@ -314,32 +314,32 @@ Also, any line starting with ! will be treated as a comment line.
                 IMPACT internal unit. The normalization constants are
                 described in the following Partcl.data.
 !
-0. 0 0 -3 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /   
-                       (write the accumulated density along R, X, Y into file 
+0. 0 0 -3 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /
+                       (write the accumulated density along R, X, Y into file
                         Xprof.data, Yprof.data, RadDens.data, radius=0.014m,
                         xmax=0.02m,pxmax=0.02 mc,ymax=0.02m,pymax=0.02 mc,
                         zmax=0.02 rad,pzmax=0.02 mc^2, if no frame range
                         is specified, the program will use the maximum
                         amplitude at given location as the frame.)
 !
-0. 0 0 -4 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /   
-                       (write the density along R, X, Y into file 
+0. 0 0 -4 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /
+                       (write the density along R, X, Y into file
                        Xprof2.data, Yprof2.data, RadDens2.data, radius=0.014m,
                        xmax=0.02m,pxmax=0.02 mc,ymax=0.02m,pymax=0.02 mc,
                        zmax=0.02 rad,pzmax=0.02 mc^2, if no frame range
                        is specified, the program will use the maximum
                        amplitude at given location as the frame.)
 !
-0. 0 0 -5 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /   
-                       (write the 2D projections of 6D distribution in 
-                       XY.data, XPx.data, XZ.data, YPy.data, YZ.data, 
+0. 0 0 -5 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /
+                       (write the 2D projections of 6D distribution in
+                       XY.data, XPx.data, XZ.data, YPy.data, YZ.data,
                        ZPz.data. radius=0.014m,
                        xmax=0.02,pxmax=0.02 mc,ymax=0.02,pymax=0.02 mc,
                        zmax=0.02 rad,pzmax=0.02 mc^2, if no frame range
                        is specified, the program will use the maximum
                        amplitude at given location as the frame.)
 !
-0. 0 0 -6 0.014 0.02 0.02 0.02 0.02 2 0.02 /   
+0. 0 0 -6 0.014 0.02 0.02 0.02 0.02 2 0.02 /
                        (write the 3D density into the file fort.8.
                        radius=0.014m,
                        xmax=0.02m,pxmax=0.02 mc,ymax=0.02m,pymax=0.02 mc,
@@ -347,12 +347,12 @@ Also, any line starting with ! will be treated as a comment line.
                        is specified, the program will use the maximum
                        amplitude at given location as the frame.)
 !
-0. 0 0 -7 /   
+0. 0 0 -7 /
                        (write the 6D phase space information and local
                        computation domain into files ph0000sN and gm0000sN.
                        This function is used for restart purpose.
 !
-0. 0 0 -21 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /  
+0. 0 0 -21 0.014 0.02 0.02 0.02 0.02 0.02 0.02 /
                       (shift the beam centroid in 6D phase space.
                       radius=0.014m (not used),
                       xshift=0.02m,pxshift=0.02rad,yshift=0.02m,pyshift=0.02rad,
@@ -373,23 +373,23 @@ integrator, the rfdataN contains the Fourier expansion coefficients for the Ez
 on the axis. These coefficients can be generated from the discrete on-axis
 Ez data using the code Rfcoef. Rfcoef will take rfdata.in as input and output
 Fourier expansion coefficients into file rfdataX. Here, X needs to be replaced by N for different type of rf cavities.
- 
+
 The initial distribution type 19 for read in distribution that is stored in the file "partcl.data".
-The first line of the partcl.data is: 
+The first line of the partcl.data is:
 # of particles, 0.0 0.0
 The rest of lines are particle information.
 There are 9 columns for each particle:
 X, Px, y, Pz, t, Pt, charge/mass, charge for each particle, id.
 Here:
 ------------------
-1st col: x normalized by c/omega  
+1st col: x normalized by c/omega
 2nd col: Px normalized by mc, here this column has to be divided by gamma beta
-         to convert to unit radian 
-3rd col: y normalized by c/omega  
+         to convert to unit radian
+3rd col: y normalized by c/omega
 4th col: Py normalized by mc, here this column has to be divided by gamma beta
          to convert to unit radian
 5th col: phase (radian)
-6th col: kinetic energy deviation (E0 -E) normalized by mc^2 
+6th col: kinetic energy deviation (E0 -E) normalized by mc^2
 7th col: q/m, for an electron, q = -1, m = 0.511001e6
 8th col: charge per macro-particle
 9th col: particle id
@@ -410,12 +410,12 @@ File fort.24 (for X) fort.25 (for Y), fort.26 (for Z): RMS size information
 ----------------------------------------------------------------
 1st col: z distance (m)
 2nd col: centroid location (m)
-3rd col: RMS size (m) 
+3rd col: RMS size (m)
 4th col: Centroid momentum (rad for fort.24 and fort.25, MeV for fort.26)
 5th col: RMS momentum (rad for fort.24 and fort.25, MeV for fort.26)
-6th col: Twiss parameter, alpha 
+6th col: Twiss parameter, alpha
 7th col: normalized RMS emittance (m-rad for transverse and degree-MeV for for
-t.26) 
+t.26)
 ----------------------------------------------------------------
 File fort.27: maximum amplitude information
 ----------------------------------------------------------------
@@ -464,14 +464,14 @@ explanation of test.in) to print the data at various locations,
 the resulting data will be in columns of the form
 x,px,y,py,t,pt, q/m, charge/per particle, id
 ------------------------------------
-1st col: x normalized by c/omega  
+1st col: x normalized by c/omega
 2nd col: Px normalized by mc, here this column has to be divided by gamma beta
-         to convert to unit radian 
-3rd col: y normalized by c/omega  
+         to convert to unit radian
+3rd col: y normalized by c/omega
 4th col: Py normalized by mc, here this column has to be divided by gamma beta
          to convert to unit radian
 5th col: phase (radian)
-6th col: kinetic energy deviation (E0 -E) normalized by mc^2 
+6th col: kinetic energy deviation (E0 -E) normalized by mc^2
 7th col: q/m, for an electron, q = -1, m = 0.511001e6
 8th col: charge per macro-particle
 9th col: particle id
@@ -494,60 +494,60 @@ x,px,y,py,t,pt, q/m, charge/per particle, id
 1)Input file: sim.dat
 -----------------------------------------------------------
 402.5e6 88.e6 939.294e6 0.0 -1.0 2 0 2 7 88.78 0.001 0.03 75.0 0.001 0.02
-                                        scaling frequency, input kinetic 
+                                        scaling frequency, input kinetic
                                         energi (eV), particle mass (eV),
                                         initial phase a(1) (rad), charge
                                         number, idata (1 for discrete RF
-                                        data, 2 for analytical function, 
+                                        data, 2 for analytical function,
                                         0(1) without(with) error study ),
-                                        2(1) given energy gain (given syn.                 
+                                        2(1) given energy gain (given syn.
                                         phase), 7 for number of elements per
                                         period, 88.78 (longitudinal 0 current
                                         phase advance), 0.001 (convergence
                                         tolerance), 0.03 (E field amplitude
                                         increase step), 75.0 (transverse 0
-                                        current phase advance), 0.001 
+                                        current phase advance), 0.001
                                         (convergence tolerance), 0.02 (B field
-                                         amplitude increase step). 
+                                         amplitude increase step).
 0.1364384E+00   40  2   0   10.000000E+00 /  length (m), # of steps, # of
                         ^                   substeps, beam line element type,
                        drift                radius.
                                             focusing strength (T/m), RF field
-                                            scaling constant, RF frequency 
-                                            (Hz), energy gain (MeV), 
-                                            synchronous phase (degree), 
+                                            scaling constant, RF frequency
+                                            (Hz), energy gain (MeV),
+                                            synchronous phase (degree),
                                             isynflag (location of synchronous,
-                                            0 at the gap center, 1 at the 
+                                            0 at the gap center, 1 at the
                                             electrical center
-0.8000000E-01   40  2   1   0.305570E+02 0.0 10.0 / length (m), # of steps, 
-                        ^                   # of substeps, beam line element 
+0.8000000E-01   40  2   1   0.305570E+02 0.0 10.0 / length (m), # of steps,
+                        ^                   # of substeps, beam line element
                        quad                 type,focusing strength (T/m),field
-                                            file ID, radius=10.0m. 
-0.8000000E-01   40  2   2   0.3E+02 0.3E+2 0.3E+2 10.0 /length, # of steps, 
-                        ^                   # of substeps, beam line element 
+                                            file ID, radius=10.0m.
+0.8000000E-01   40  2   2   0.3E+02 0.3E+2 0.3E+2 10.0 /length, # of steps,
+                        ^                   # of substeps, beam line element
                    Uniform focusing         type,kx0^2,ky0^2,kz0^2,radius
-0.8000000E-01   40  2   3   0.305570E+02 0.0 10.0 / length (m), # of steps, 
-                        ^                   # of substeps, beam line element 
+0.8000000E-01   40  2   3   0.305570E+02 0.0 10.0 / length (m), # of steps,
+                        ^                   # of substeps, beam line element
                    solenoid                 type,focusing field Bz (T),field
-                                            file ID, radius=10.0m. 
-0.8000000E-01   40  2   4   0.305570E+02 0.0 0.0 10.0 /length, # of steps, 
-                        ^                    # of substeps, beam line element 
+                                            file ID, radius=10.0m.
+0.8000000E-01   40  2   4   0.305570E+02 0.0 0.0 10.0 /length, # of steps,
+                        ^                    # of substeps, beam line element
                       dipole                 type, Bx(T), By(T), field
-                                            file ID, radius=10.0m. 
+                                            file ID, radius=10.0m.
 0.6060880E+00  400  2   103  0.1000E+07 805.e6 -30.0 2.0 1.0 10.0 1.0 /
-                        ^                  length (m), # of steps, # of 
-                       CCL                 sub steps, beam line element type 
+                        ^                  length (m), # of steps, # of
+                       CCL                 sub steps, beam line element type
                                            (CCDTL, CCL, SC),
-                                           scaling constant, RF freq., 
+                                           scaling constant, RF freq.,
                                            synchronous phase (degree), energy
                                            gain (MeV), field file ID, radius,
                                            isynflag (location of synchronous,
                                            >=1 at the gap center, 0 at the
                                            electrical center).
 0.6060880E+00  400  2   101  0.1000E+07 805.e6 -30.0 2.0 1.0 10.0 1.0 0.01, 1.0 0.01 1.0 /
-                        ^                  length (m), # of steps, # of 
-                        DTL                sub steps, beam line element type, 
-                                           scaling constant, RF freq., 
+                        ^                  length (m), # of steps, # of
+                        DTL                sub steps, beam line element type,
+                                           scaling constant, RF freq.,
                                            synchronous phase (degree), energy
                                            gain (MeV), field file ID, radius,
                                            isynflag (location of synchronous,
@@ -556,9 +556,9 @@ x,px,y,py,t,pt, q/m, charge/per particle, id
                                            quad 1 strength, quad 2 length,
                                            quad 2 strength.
 0.6060880E+00  400  2   105  0.1000E+07 805.e6 -30.0 2.0 1.0 10.0 1.0 2.0 /
-                        ^                  length (m), # of steps, # of 
-                      Sol+RF               sub steps, beam line element type, 
-                                           scaling constant, RF freq., 
+                        ^                  length (m), # of steps, # of
+                      Sol+RF               sub steps, beam line element type,
+                                           scaling constant, RF freq.,
                                            synchronous phase (degree), energy
                                            gain (MeV), field file ID, radius,
                                            isynflag (location of synchronous,
@@ -569,7 +569,7 @@ x,px,y,py,t,pt, q/m, charge/per particle, id
 ! -----------------------------------
 1.0 1.0 1.0 1.0 1.0 1.0 1.0   Quad x, y, z displacement errors, pitch, yaw,
                               roll errors, and gradient error
-1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0  RF cavity x, y, z displacement errors, pitch,                                 yaw, roll errors, field, and phase errors 
+1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0  RF cavity x, y, z displacement errors, pitch,                                 yaw, roll errors, field, and phase errors
 ! -----------------------------------
 3) Input file: rfdatax: x is the field file ID.
 Warning: Ez' has to be accurate. Discrete data for Ez and Ez' is recomended.

--- a/GUI/iGUI.py
+++ b/GUI/iGUI.py
@@ -1,13 +1,13 @@
 def runGUI():
-  
-  import sys; 
+
+  import sys;
   if not "./src/" in sys.path:
-      sys.path.append("./src/") 
+      sys.path.append("./src/")
   if not 'ImpactMainWindow' in sys.modules:
       ImpactMainWindow = __import__('ImpactMainWindow')
   else:
       import ImpactMainWindow
-      #ImpactMainWindow = eval('reload(ImpactMainWindow)') 
+      #ImpactMainWindow = eval('reload(ImpactMainWindow)')
   root = ImpactMainWindow.ImpactMainWindow()
   ImpactMainWindow.MyMenu(root)
 
@@ -26,5 +26,3 @@ def runGUI():
   root.mainloop()
   root.console.stop()
   return root.beam,root.lattice
-  
-  

--- a/GUI/src/ConvertFunc.py
+++ b/GUI/src/ConvertFunc.py
@@ -1,7 +1,7 @@
 # convert from the Trace3d twiss parameter to the IMPACT input distribution parameters.
 # Here, the TRACE3d units are, alpha, beta (m/rad), emittance (mm-mrad, rms, unnormalized)
 #                              alpha_z,beta_z (deg/keV), emittance (deg-keV,rms)
-#frq(Hz),mass(eV£©,kine(eV)
+#frq(Hz),mass(eV),kine(eV)
 
 
 import math
@@ -10,64 +10,64 @@ def Twiss2Sigma(alpha,beta,emittance,freq,mass,kine):
     Egamma = 1 + kine/mass
     Ebeta = math.sqrt(1.0-1.0/Egamma/Egamma)
     xl=2.99792458e8/(2.0*math.pi*freq)     # Length scale
-    
+
     emittance = emittance *1.0e-6 # unnormalized emittance
-    
+
     sig1=math.sqrt(beta*emittance/(1.0+alpha**2))
     sig2=math.sqrt(emittance/beta)
     rho=alpha/math.sqrt(1.0+alpha**2)
-    
+
     sig1 = sig1 / xl
     sig2 = sig2 * Egamma*Ebeta
 
     #gammabeta is needed because <x'^2>=emittance*gamma instead of <(px/mc)^2>
-    
+
     return sig1, sig2, rho
 
 def Twiss2SigmaZ(alpha,beta,emittance,freq,mass,kine):
     Egamma = 1 + kine/mass
     Ebeta = math.sqrt(1.0-1.0/Egamma/Egamma)
     xl=2.99792458e8/(2.0*math.pi*freq)     # Length scale
-    
+
     beta=1000.0*beta
     eps=1.0e-3*emittance
     sig1=math.sqrt(beta*eps/(1.0+alpha**2))/(180.0/math.pi)
     sig2=math.sqrt(eps/beta)/mass*1.0e6
     rho=-alpha/math.sqrt(1.0+alpha**2)
-    
+
     return sig1, sig2, rho
 
 def Sigma2Twiss(sig1, sig2, rho, freq,mass,kine):
     Egamma = 1 + kine/mass
     Ebeta = math.sqrt(1.0-1.0/Egamma/Egamma)
     xl=2.99792458e8/(2.0*math.pi*freq)     # Length scale
-    
+
     sig1        = sig1 * xl
     #gammabeta is needed because <x'^2>=emittance*gamma instead of <(px/mc)^2>
     sig2        = sig2 / (Egamma*Ebeta)
 
-    alpha       = math.sqrt(rho**2/(1-rho**2)) * (1 if rho>0 else -1) 
+    alpha       = math.sqrt(rho**2/(1-rho**2)) * (1 if rho>0 else -1)
     beta        = sig1/sig2 * math.sqrt(1+alpha**2)
     emittance   = sig1*sig2 * math.sqrt(1+alpha**2)
 
     emittance   = emittance / 1.0e-6 #mm*mrad
-    
+
     return alpha,beta,emittance
 
 def Sigma2TwissZ(sig1, sig2, rho, freq,mass,kine):
     Egamma = 1 + kine/mass
     Ebeta = math.sqrt(1.0-1.0/Egamma/Egamma)
     xl=2.99792458e8/(2.0*math.pi*freq)     # Length scale
-    
+
     sig1        = sig1*(180.0/math.pi)
     #gammabeta is needed because <x'^2>=emittance*gamma instead of <(px/mc)^2>
     sig2        = sig2 *mass/1.0e6
-    
-    alpha       = math.sqrt(rho**2/(1-rho**2)) * (1 if rho>0 else -1) 
-    beta        = sig1/sig2 * math.sqrt(1+alpha**2)  
+
+    alpha       = math.sqrt(rho**2/(1-rho**2)) * (1 if rho>0 else -1)
+    beta        = sig1/sig2 * math.sqrt(1+alpha**2)
     emittance   = sig1*sig2 * math.sqrt(1+alpha**2)
-    
+
     beta        = beta      / 1000.0    #deg/keV
     emittance   = emittance / 1.0e-3    #deg*keV
-    
+
     return alpha,beta,emittance

--- a/GUI/src/ImpactFile.py
+++ b/GUI/src/ImpactFile.py
@@ -21,7 +21,7 @@ def conciseReadInput(inputFileName):
                 dataList[i]=dataList[i].lstrip()[:index].rstrip()+'\n'
         i=i+1
     dataList  = [line.split() for line in dataList ]
-    
+
     for i in range(0,len(dataList)):
         for j in range(0,len(dataList[i])):
             dataList[i][j] = DtoE(dataList[i][j])
@@ -43,7 +43,7 @@ def conciseWriteInput(dataList,outputFileName):
 
 
 def DtoE(word):
-    if 'D' in word or 'd' in word: 
+    if 'D' in word or 'd' in word:
         try:
             temp = float(word.replace('D','E',1).replace('d','e',1))
             return str(temp)

--- a/GUI/src/ImpactMainWindow.py
+++ b/GUI/src/ImpactMainWindow.py
@@ -100,15 +100,15 @@ class ImpactMainWindow(tk.Tk):
     AccKernel = 'ImpactT'
     ImpactThread=threading.Thread()
     ImpactThread.setDaemon(True)
-    def __init__(self, master=None):  
+    def __init__(self, master=None):
         tk.Tk.__init__(self, master)
         self.title("Impact")
         self.createWidgets(master)
         #self.master.iconbitmap()
-          
+
         for item in ImpactMainWindow.LABEL_TEXT:
             print(item)
-            
+
     def createWidgets(self, master):
         self.t= startWindow(self)
         w1  = 400
@@ -121,7 +121,7 @@ class ImpactMainWindow(tk.Tk):
         self.t.geometry('%dx%d+%d+%d' % (w1, h1, x1, y1))
         self.frame_left = tk.Frame(self, height =_height, width = _width)
         self.frame_left.grid(row=0,column=0)
-        
+
         self.frame_logo = tk.Frame(self.frame_left, height =_height/10, width = _width)
         self.frame_logo.pack(side = 'top')
         #print(resource_path(os.path.join('icon','ImpactT.gif')))
@@ -133,7 +133,7 @@ class ImpactMainWindow(tk.Tk):
         except:
             self.label_logo  = tk.Label(self.frame_logo,bitmap='error')
             self.label_logo.pack(fill = 'y',side = 'left')
-        
+
         '''
         LARGE_FONT= ("Helvetica", 20,'italic')
         self.button_switch = tk.Button(self.frame_logo)
@@ -143,18 +143,18 @@ class ImpactMainWindow(tk.Tk):
         self.button_switch.pack(fill = 'both',expand =1,side = 'top',padx = 150)
         '''
         """Frame1: CPU GPU information"""
-        self.frame_input1 = tk.LabelFrame(self.frame_logo, height =_height/10, width = _width, 
+        self.frame_input1 = tk.LabelFrame(self.frame_logo, height =_height/10, width = _width,
                                                 text="Configuration")
         #self.frame_input1.grid(row=1,column=0,columnspan=2,sticky='W')
         self.frame_input1.pack(side = 'right')
-        
+
         self.frame_CPU = tk.Frame(self.frame_input1, height =_height/10, width = _width)
         self.frame_CPU.pack(side = 'top')
-        
+
         vcmd = (self.register(self.validate),
                 '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
         self.label_noc1 = tk.Label(self.frame_CPU, text="# of cores at Y",pady=1)
-        self.entry_noc1 = tk.Entry(self.frame_CPU, 
+        self.entry_noc1 = tk.Entry(self.frame_CPU,
                                    validate = 'key',
                                    validatecommand = vcmd,
                                    width=4)
@@ -163,14 +163,14 @@ class ImpactMainWindow(tk.Tk):
         self.entry_noc1.pack(side='left')
 
         self.label_noc2 = tk.Label(self.frame_CPU, text="# of cores at Z",pady=1)
-        self.entry_noc2 = tk.Entry(self.frame_CPU, 
+        self.entry_noc2 = tk.Entry(self.frame_CPU,
                                    validate = 'key',
                                    validatecommand = vcmd,
                                    width=4)
         self.entry_noc2.insert(0, '1')
         self.label_noc2.pack(side='left')
         self.entry_noc2.pack(side='left')
-        
+
         self.GPUflag   = tk.IntVar()
         self.check_GPU  = tk.Checkbutton(self.frame_CPU, text="GPU", variable=self.GPUflag)
         self.check_GPU.pack(side='left')
@@ -182,32 +182,32 @@ class ImpactMainWindow(tk.Tk):
         #self.entry_dic.insert(0, os.path.dirname(os.path.abspath(__file__)))
         self.entry_dic.insert(0, sys.path[0])
         self.entry_dic.pack(side='left')
-        
+
         self.button_dic = tk.Button(self.frame_input1)
         self.button_dic["text"]        = "..."
         self.button_dic["command"]     = lambda: self.changeDic()
         self.button_dic.pack(side = 'left')
-        
+
         self.button_dic.bind("<Enter>", lambda event, h=self.button_dic: h.configure(bg="#00CD00"))
         self.button_dic.bind("<Leave>", lambda event, h=self.button_dic: h.configure(bg="#FFFFFF"))
-        
+
         """Frame2: Time step"""
-        self.frame1 = tk.Frame(self.frame_left, 
+        self.frame1 = tk.Frame(self.frame_left,
                                height =_height/2, width = _width)
         #self.frame_input2.grid(row=2,column=0,sticky='W')
         self.frame1.pack(fill = 'x',side = 'top')
-        
-        self.frame_input2 = tk.LabelFrame(self.frame1, 
-                                          height =_height/2, width = _width, 
+
+        self.frame_input2 = tk.LabelFrame(self.frame1,
+                                          height =_height/2, width = _width,
                                           text="Numerical parameters")
         #self.frame_input2.grid(row=2,column=0,sticky='W')
         self.frame_input2.pack(fill = 'x',side = 'left')
         rowtemp=1
         frame2width = 7
-        
+
         """dt"""
         self.label_dt    = tk.Label(self.frame_input2, text="Timestep")
-        self.entry_dt    = tk.Entry(self.frame_input2, 
+        self.entry_dt    = tk.Entry(self.frame_input2,
                                     validate = 'key',
                                     validatecommand = vcmd,
                                     width=frame2width)
@@ -237,7 +237,7 @@ class ImpactMainWindow(tk.Tk):
         self.label_Np.grid(row=rowtemp,sticky='W')
         self.entry_Np.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Grid X"""
         self.label_Ngx   = tk.Label(self.frame_input2, text="Grid number X")
         self.entry_Ngx   = tk.Entry(self.frame_input2,
@@ -248,7 +248,7 @@ class ImpactMainWindow(tk.Tk):
         self.label_Ngx.grid(row=rowtemp,sticky='W')
         self.entry_Ngx.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Grid Y"""
         self.label_Ngy   = tk.Label(self.frame_input2, text="Grid number Y")
         self.entry_Ngy   = tk.Entry(self.frame_input2,
@@ -259,7 +259,7 @@ class ImpactMainWindow(tk.Tk):
         self.label_Ngy.grid(row=rowtemp,sticky='W')
         self.entry_Ngy.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Grid Z"""
         self.label_Ngz   = tk.Label(self.frame_input2, text="Grid number Z")
         self.entry_Ngz   = tk.Entry(self.frame_input2,
@@ -271,30 +271,30 @@ class ImpactMainWindow(tk.Tk):
         self.entry_Ngz.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
 
-        
+
         """Twiss"""
         twisswidth = [9,11,11]
-        self.frame_Twiss = tk.LabelFrame(self.frame1, 
+        self.frame_Twiss = tk.LabelFrame(self.frame1,
                                          height =_height/2, width = _width, text="Beam Twiss")
         self.frame_Twiss.pack(fill = 'y',side = 'left')
-            
+
         self.twiss_t = []
         self.twiss_Tchara = ["alpha","beta","emittance"]
         for column in range(3):
-            label = tk.Label(self.frame_Twiss, text=self.twiss_Tchara[column], 
+            label = tk.Label(self.frame_Twiss, text=self.twiss_Tchara[column],
                             borderwidth=0,
                             width=twisswidth[column])
             label.grid(row=0, column=column+1, sticky="ns", padx=1, pady=1)
             self.twiss_t.append(label)
-        
+
         self.twiss_x = []
         self.twiss_xchara = ["X","Y","Z"]
         for row in range(3):
-            label = tk.Label(self.frame_Twiss, text=self.twiss_xchara[row], 
+            label = tk.Label(self.frame_Twiss, text=self.twiss_xchara[row],
                                  borderwidth=0, width=2)
             label.grid(row=row+1, column=0, sticky="ns", padx=1, pady=1)
             self.twiss_x.append(label)
-        
+
         '''Twiss and Sigma string'''
         self.twiss_param = [["3.84562e-4","0.001" ,"0.0", "1.0","1.0","0.0","0.0"],
                             ["3.84562e-4","0.001" ,"0.0", "1.0","1.0","0.0","0.0"],
@@ -306,7 +306,7 @@ class ImpactMainWindow(tk.Tk):
                 t = tk.StringVar(value=self.twiss_param[row][column])
                 current_row.append(t)
             self.string_sigma.append(current_row)
-        
+
         self.string_twiss = []
         for row in range(3):
             current_row = []
@@ -315,24 +315,24 @@ class ImpactMainWindow(tk.Tk):
                 current_row.append(t)
             self.string_twiss.append(current_row)
 
-        '''Twiss Entry'''   
+        '''Twiss Entry'''
         self.entry_twiss = []
         for row in range(3):
             current_row = []
             for column in range(3):
-                label = tk.Entry(self.frame_Twiss, 
-                                 textvariable=self.string_twiss[row][column], 
+                label = tk.Entry(self.frame_Twiss,
+                                 textvariable=self.string_twiss[row][column],
                                  borderwidth=0,
                                  width=twisswidth[column])
                 label.grid(row=row+1, column=column+1, sticky="ns", padx=2, pady=1)
                 current_row.append(label)
             self.entry_twiss.append(current_row)
-        
+
         """Distribution"""
         self.frame_Dist = tk.Frame(self.frame_Twiss,
                                    height =_height/2, width = _width)
         self.frame_Dist.grid(row=4, column=0, rowspan=1, columnspan=4,sticky="nsew", padx=1, pady=1)
-        
+
         self.label_dist    = tk.Label(self.frame_Dist, text="Distribution")
         self.label_dist.grid(row=0, column=0,
                              sticky="nw", padx=1, pady=1)
@@ -344,7 +344,7 @@ class ImpactMainWindow(tk.Tk):
                                              'CylcoldZSob','Other'])
         self.distType.grid(row=0, column=1,
                              sticky="nsew", padx=1, pady=1)
-        
+
         """Particle Type"""
         self.label_ptcType    = tk.Label(self.frame_Dist, text="Particle")
         self.label_ptcType.grid(row=1, column=0,
@@ -356,14 +356,14 @@ class ImpactMainWindow(tk.Tk):
                                      values=['Electron', 'Proton', 'Positron', 'Antiproton','Other'])
         self.ptcType.grid(row=1, column=1,
                           sticky="nsew", padx=1, pady=1)
-        
+
         """Particle"""
-        self.frame_Particle = tk.LabelFrame(self.frame1, 
-                                            height =_height/2, width = _width, 
+        self.frame_Particle = tk.LabelFrame(self.frame1,
+                                            height =_height/2, width = _width,
                                             text="Beam")
         self.frame_Particle.pack(fill = 'both',side = 'top')
         rowtemp=0
-                
+
         """Current"""
         self.label_cur   = tk.Label(self.frame_Particle, text="Current(A)")
         self.entry_cur   = tk.Entry(self.frame_Particle,
@@ -374,7 +374,7 @@ class ImpactMainWindow(tk.Tk):
         self.label_cur.grid(row=rowtemp,sticky='W')
         self.entry_cur.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Energy"""
         self.label_Ek    = tk.Label(self.frame_Particle, text="Energy(eV)")
         self.entry_Ek    = tk.Entry(self.frame_Particle,
@@ -385,7 +385,7 @@ class ImpactMainWindow(tk.Tk):
         self.label_Ek.grid(row=rowtemp,sticky='W')
         self.entry_Ek.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Frequency"""
         self.label_frq   = tk.Label(self.frame_Particle, text="Frequency(Hz)")
         self.entry_frq   = tk.Entry(self.frame_Particle,
@@ -396,12 +396,12 @@ class ImpactMainWindow(tk.Tk):
         self.label_frq.grid(row=rowtemp,sticky='W')
         self.entry_frq.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         '''Advanced Setting'''
         self.MPI_EXE      =tk.StringVar(value=_MPINAME)
         self.IMPACT_T_EXE =tk.StringVar(value=os.path.join(sys.path[0],'src',_IMPACT_T_NAME))
         self.IMPACT_Z_EXE =tk.StringVar(value=os.path.join(sys.path[0],'src',_IMPACT_Z_NAME))
-        
+
         self.Nbunch      = tk.StringVar(value='1')
         self.Dim         = tk.StringVar(value='6')
         self.Flagmap     = tk.StringVar(value='Linear')
@@ -410,17 +410,17 @@ class ImpactMainWindow(tk.Tk):
         self.Flagimag    = tk.StringVar(value='0')
         self.Zimage      = tk.StringVar(value='0.02')
         self.Flagbc      = tk.StringVar(value='Trans:open,  Longi:open')
-        
+
         self.Xrad        = tk.StringVar(value='0.15')
         self.Yrad        = tk.StringVar(value='0.15')
         self.Zrad        = tk.StringVar(value='1.0e5')
-        
+
         self.FlagRestart  = tk.StringVar(value='0')
-        
+
         self.Nemission   = tk.StringVar(value='1')
         self.Temission   = tk.StringVar(value='8.0e-11')
         self.Tinitial    = tk.StringVar(value='0.0')
-        
+
         '''Advanced Set for ImpactZ'''
         self.FlagOutput_Z    = tk.StringVar(value='Standard')
         self.ZperiodSize     = tk.StringVar(value='0.1')
@@ -428,42 +428,42 @@ class ImpactMainWindow(tk.Tk):
         self.NpList          = tk.StringVar(value='16000')
         self.CurrentList     = tk.StringVar(value='0.0')
         self.SchargeList     = tk.StringVar(value='1.06577993775845e-09')
-           
+
         self.button_AdvancedControl = tk.Button(self.frame1,text='Advanced Setting',
                                                 command = self.makeAdvancedSet)
         self.button_AdvancedControl.pack(fill='both',expand=1,padx = 15, pady=20)
         LARGE_FONT= ("Helvetica", 10)
         self.button_AdvancedControl["font"]        = LARGE_FONT
-        
+
         self.button_AdvancedControl.bind("<Enter>", lambda event, h=self.button_AdvancedControl: h.configure(bg="#00CD00"))
         self.button_AdvancedControl.bind("<Leave>", lambda event, h=self.button_AdvancedControl: h.configure(bg="#FFFFFF"))
-        
+
         """Lattice"""
-        self.frame_input3 = tk.LabelFrame(self.frame_left, 
+        self.frame_input3 = tk.LabelFrame(self.frame_left,
                                           height =_height/6, width = _width,
                                           text="Lattice")
         self.frame_input3.pack(fill="both", expand=1, side=tk.TOP)
-        
+
         self.lattice = LatticeFrame.LatticeFrameC(self.frame_input3, height = _height/6,width = _width)
         self.lattice.pack(fill="both", expand=1, side=tk.TOP)
-              
+
         """Console"""
-        self.frame_console = tk.LabelFrame(self.frame_left, 
+        self.frame_console = tk.LabelFrame(self.frame_left,
                                            height =_height/5, width = _width,
                                            text="Console")
         self.frame_console.pack(fill="both", expand=1, side=tk.TOP)
-        
+
         self.console_sv = tk.Scrollbar(self.frame_console, orient=tk.VERTICAL)
         self.console = LatticeFrame.ConsoleText(self.frame_console,
                                    width = LatticeFrame._TextWidth, height=LatticeFrame._TextHeight,
                                    bg='black',fg='green', yscrollcommand=self.console_sv.set)
-        self.console_sv.config(command=self.console.yview)  
-        self.console_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N)  
+        self.console_sv.config(command=self.console.yview)
+        self.console_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N)
         self.console.pack(fill="both", expand=1, side=tk.TOP)
         self.console.start()
-        
+
         """Control"""
-        
+
         self.frame_control = tk.Frame(self.frame_left, height =_height/5, width = _width)
         self.frame_control.pack(fill="both", expand=1, side=tk.TOP)
         '''
@@ -471,23 +471,23 @@ class ImpactMainWindow(tk.Tk):
                                           height =_height/5, width = _width,
                                           text="Plot")
         self.frame_output.pack(side='left')
-        
+
         self.frame_plotControl = PlotControlFrame(self.frame_output,
                                              height =_height/5, width = _width)
         self.frame_plotControl.pack(side='left')
         '''
-        
+
         '''Final button'''
-        LARGE_FONT= ("Helvetica", 20,'italic')                
+        LARGE_FONT= ("Helvetica", 20,'italic')
         self.button_initial = tk.Button(self.frame_control)
         self.button_initial["text"]        = "Pre-Process"
         self.button_initial["font"]        = LARGE_FONT
         self.button_initial["command"]     = lambda: self.thread_it(self.preprocessing)
         self.button_initial.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.button_initial.bind("<Enter>", lambda event, h=self.button_initial: h.configure(bg="#00CD00"))#green
         self.button_initial.bind("<Leave>", lambda event, h=self.button_initial: h.configure(bg="#FFFFFF"))
-        
+
         self.button_run = tk.Button(self.frame_control)
         self.button_run["text"]         = "Run"
         self.button_run["font"]         = LARGE_FONT
@@ -495,34 +495,34 @@ class ImpactMainWindow(tk.Tk):
         #self.button_run["command"]      = lambda: self.startImpact()
         self.button_run.pack(fill = 'both',expand =1,side = 'left')
         self.run_lock = threading.RLock()
-        
+
         self.button_run.bind("<Enter>", lambda event, h=self.button_run: h.configure(bg="#00CD00"))#green
         self.button_run.bind("<Leave>", lambda event, h=self.button_run: h.configure(bg="#FFFFFF"))
-        
+
         self.button_plot = tk.Button(self.frame_control)
         self.button_plot["text"]        = "Post-Process"
         self.button_plot["font"]        = LARGE_FONT
         self.button_plot["command"]     = lambda: self.makeAdvancedPlot()
         self.button_plot.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.button_plot.bind("<Enter>", lambda event, h=self.button_plot: h.configure(bg="#00CD00"))#green
         self.button_plot.bind("<Leave>", lambda event, h=self.button_plot: h.configure(bg="#FFFFFF"))
-        
-        
+
+
         '''
         self.test = tk.Button(self.frame_left)
         self.test["text"] = "debug"
         self.test["command"] = lambda: self.debug()
         self.test.pack(fill = 'both',expand =1,side = 'top')
-        
+
         self.test2 = tk.Button(self.frame_left)
         self.test2["text"] = "debug2"
         self.test2["command"] = lambda: self.debug2()
         self.test2.pack(fill = 'both',expand =1,side = 'top')
         '''
         self.updateTwissLock    =0
-        
-        for i in range(3):    
+
+        for i in range(3):
             for j in range(3):
                 self.string_sigma[i][j].trace('w',lambda a,b,c,h=i: self.updateTwiss(h))
                 self.string_twiss[i][j].trace('w',lambda a,b,c,h=i: self.updateSigma(h))
@@ -534,7 +534,7 @@ class ImpactMainWindow(tk.Tk):
         self.ptcTypeComx.trace('w', self.updatePtc)
         self.ptcMass.trace('w', self.updatePtcType)
         self.ptcCharge.trace('w', self.updatePtcType)
-        
+
         self.updateDistTypeLock  =0
         self.distTypeComx.trace('w', self.updateDist)
         self.distTypeNumb.trace('w', self.updateDistType)
@@ -552,7 +552,7 @@ class ImpactMainWindow(tk.Tk):
         '''degue'''
         #self.t.startImpactT(self)
         #self.makeAdvancedPlot()
-    
+
     #(Kilean)#######################################################
     def getBeam4pImpact(self):
       self.beam = {
@@ -577,7 +577,7 @@ class ImpactMainWindow(tk.Tk):
         'frequency': float(self.entry_frq.get()), # Hz
         'phase': float(self.Tinitial.get()),   #radian
         'mesh_x' : int(self.entry_Ngx.get()),
-        'mesh_y' : int(self.entry_Ngy.get()), 
+        'mesh_y' : int(self.entry_Ngy.get()),
         'mesh_z' : int(self.entry_Ngz.get())}
       if self.distType.get() == 'Other':
         self.beam['distribution id'] = int(self.distTypeNumb.get())
@@ -598,35 +598,35 @@ class ImpactMainWindow(tk.Tk):
             if elem : #check if elem is not empty
                 lattice.append(elem)
         return lattice
-      def str2elem(elemStr): 
+      def str2elem(elemStr):
         elemStr = elemStr.split()
         elemID=int(float(elemStr[3]))
         if elemID == 0:
             elemtDict = {'type':'drift',
                          'length': float(elemStr[0]),
-                         'n_sckick': int(elemStr[1]), 
-                         'n_map': int(elemStr[2]), 
+                         'n_sckick': int(elemStr[1]),
+                         'n_map': int(elemStr[2]),
                          'radius': float(elemStr[4])
-                        }   
+                        }
         elif elemID == 1:
             elemtDict = {'type':'quad',
                          'length': float(elemStr[0]),
-                         'n_sckick': int(elemStr[1]), 
-                         'n_map': int(elemStr[2]), 
-                         'B1': float(elemStr[4]), 
-                         'input file id': int(elemStr[5]), 
+                         'n_sckick': int(elemStr[1]),
+                         'n_map': int(elemStr[2]),
+                         'B1': float(elemStr[4]),
+                         'input file id': int(elemStr[5]),
                          'radius': float(elemStr[6]) }
             if len(elemStr)>8:
                          elemtDict['dx']=float(elemStr[7])
             if len(elemStr)>9:
-                         elemtDict['dy']=float(elemStr[8]) 
+                         elemtDict['dy']=float(elemStr[8])
         elif elemID == 4:
             elemtDict = {'type':'bend',
                          'length': float(elemStr[0]),
-                         'n_sckick': int(elemStr[1]), 
-                         'n_map': int(elemStr[2]), 
-                         'angle': float(elemStr[4]), 
-                         'k1': float(elemStr[5]), 
+                         'n_sckick': int(elemStr[1]),
+                         'n_map': int(elemStr[2]),
+                         'angle': float(elemStr[4]),
+                         'k1': float(elemStr[5]),
                          'input switch': int(float(elemStr[6])),
                          'radius': float(elemStr[7]),
                          'entrance edge': float(elemStr[8]),
@@ -634,43 +634,43 @@ class ImpactMainWindow(tk.Tk):
                          'entrance curvature': float(elemStr[10]),
                          'exit curvature': float(elemStr[11]),
                          'FINT': float(elemStr[12]),
-                        }                     
+                        }
         elif elemID == 104:
             elemtDict= {'type':'scrf',
                         'length': float(elemStr[0]),
-                        'n_sckick': int(elemStr[1]), 
-                        'n_map': int(elemStr[2]), 
-                        'scale': float(elemStr[4]), 
-                        'frequency': float(elemStr[5]), 
-                        'phase': float(elemStr[6]), 
-                        'input file id': int(elemStr[7]), 
+                        'n_sckick': int(elemStr[1]),
+                        'n_map': int(elemStr[2]),
+                        'scale': float(elemStr[4]),
+                        'frequency': float(elemStr[5]),
+                        'phase': float(elemStr[6]),
+                        'input file id': int(elemStr[7]),
                         'radius': float(elemStr[8])
                        }
         elif elemID == -2:
             elemtDict= {'type':'write full',
-                        'file id': int(elemStr[2])}                   
+                        'file id': int(elemStr[2])}
         elif elemID == -7:
             elemtDict= {'type':'restart'}
         elif elemID == -99:
-            elemtDict= {'type':'halt'} 
+            elemtDict= {'type':'halt'}
         else :
             elemtDict= {}
         return elemtDict
       latticeStr = self.lattice.getHide().splitlines()
       self.lattice = str2lattice(latticeStr)
-      
+
     def exit(self):
       self.getBeam4pImpact()
       self.getLattice4pImpact()
       self.destroy()
-      
+
     #######################################################(Kilean)#
     def debug(self):
         self.lattice.convertNtoW(self.lattice.get('0.0', tk.END))
-    
+
     def debug2(self):
         self.lattice.updateHide()
-        
+
     def changeDic(self):
         filename = filedialog.askdirectory(parent=self)
         try:
@@ -679,16 +679,16 @@ class ImpactMainWindow(tk.Tk):
             os.chdir(filename)
         except:
             print("Cannot change the folder. Check the path Please.")
-        
+
         self.entry_dic.delete(0, 'end')
         self.entry_dic.insert(0, filename)
         print(filename)
-    
+
     def updatePtc(self,*args):
         if self.updatePtcTypeLock ==1:
             return
         self.updatePtcTypeLock = 1
-        
+
         if self.ptcTypeComx.get() !='Other':
             try:
                 ptc = PARTICLE_TYPE[self.ptcTypeComx.get()].split()
@@ -697,12 +697,12 @@ class ImpactMainWindow(tk.Tk):
             except:
                 pass
         self.updatePtcTypeLock = 0
-    
+
     def updatePtcType(self,*args):
         if self.updatePtcTypeLock ==1:
             return
         self.updatePtcTypeLock = 1
-        
+
         invermap = dict(map(lambda t:(t[1],t[0]), PARTICLE_TYPE.items()))
         ptcFound = 0
         for key in invermap.keys():
@@ -723,7 +723,7 @@ class ImpactMainWindow(tk.Tk):
         if self.updateDistTypeLock ==1:
             return
         self.updateDistTypeLock = 1
-        
+
         if self.distTypeComx.get() != 'Other':
             try:
                 if self.AccKernel=='ImpactT':
@@ -738,14 +738,14 @@ class ImpactMainWindow(tk.Tk):
             except:
                 pass
         self.updateDistTypeLock = 0
-        
+
     def updateDistType(self,*args):
         if len(self.distTypeNumb.get())==0:
             return
         if self.updateDistTypeLock ==1:
             return
         self.updateDistTypeLock = 1
-        
+
         invermap = {'':''}
         if self.AccKernel=='ImpactT':
             invermap = dict(map(lambda t:(t[1],t[0]), DISTRIBUTION_T_TYPE.items()))
@@ -767,12 +767,12 @@ class ImpactMainWindow(tk.Tk):
         if distFound==0:
             self.distTypeComx.set('Other')
         self.updateDistTypeLock = 0
-        
+
     def updateTwiss(self,i):
         if self.updateTwissLock ==1:
             return
         self.updateTwissLock = 1
-        
+
         try:
             s1,s2,s3 = float(self.string_sigma[i][0].get()), float(self.string_sigma[i][1].get()), float(self.string_sigma[i][2].get())
             f, m, k  = float(self.entry_frq.get()),    float(self.ptcMass.get()),      float(self.entry_Ek.get())
@@ -780,7 +780,7 @@ class ImpactMainWindow(tk.Tk):
             if i==1 or i==0:
                 re[0],re[1],re[2] = ConvertFunc.Sigma2Twiss(s1,s2,s3, f,m,k)
             if i==2:
-                re[0],re[1],re[2] = ConvertFunc.Sigma2TwissZ(s1,s2,s3, f,m,k)    
+                re[0],re[1],re[2] = ConvertFunc.Sigma2TwissZ(s1,s2,s3, f,m,k)
             digits = [2,4,4]
             for j in range(3):
                 #if not math.isclose(re[j], float(self.string_twiss[i][j].get()),rel_tol=1e-06):
@@ -789,7 +789,7 @@ class ImpactMainWindow(tk.Tk):
             #print('Error')
             pass
         self.updateTwissLock = 0
-        
+
     def updateSigma(self,i):
         if self.updateTwissLock == 1:
             return
@@ -813,14 +813,14 @@ class ImpactMainWindow(tk.Tk):
             #print('Error')
             pass
         self.updateTwissLock = 0
-        
+
     def preprocessing(self):
         try:
             os.chdir(self.entry_dic.get())
         except:
             print("Error: cannot get to the dictionary" + self.entry_dic.get())
             return
-        
+
         if self.AccKernel=='ImpactT':
             np = self.save('ImpactT.in')
             self.button_run     .config(state='disable')
@@ -838,14 +838,14 @@ class ImpactMainWindow(tk.Tk):
             #PreProcessing.main('Z')
         else:
             print('Cannot find kernel: '+self.AccKernel)
-    
+
     def switch(self):
         if self.AccKernel=='ImpactT':
             self.switchToImpactZ()
         elif self.AccKernel == 'ImpactZ':
             self.switchToImpactT()
         print("Switch kernel to "+self.AccKernel)
-        
+
     def switchToImpactZ(self):
         self.AccKernel='ImpactZ'
         try:
@@ -853,14 +853,14 @@ class ImpactMainWindow(tk.Tk):
             self.AdvancedPlot.destroy()
         except:
             pass
-        
+
         try:
             self.label_logo.config(image = self.logo_ImpactZ)
         except:
             self.label_logo.config(bitmap='error')
         self.entry_Nstep.config(state='disabled')
         self.entry_dt.config(state='disabled')
-        
+
         distZ=['Uniform', 'Gauss', 'SemiGauss',
                'WaterBag','KV', 'Read',
                'Multi-charge-state WaterBag',
@@ -870,7 +870,7 @@ class ImpactMainWindow(tk.Tk):
             self.distTypeComx.set(distZ[0])
         self.distType['values'] =distZ
         self.lattice.titleZ()
-        
+
     def switchToImpactT(self):
         self.AccKernel='ImpactT'
         try:
@@ -892,7 +892,7 @@ class ImpactMainWindow(tk.Tk):
         if self.distTypeComx.get() not in distT:
             self.distTypeComx.set('Other')
         self.lattice.titleT()
-        
+
     def makeAdvancedSet(self):
         try:
             self.AdvancedSet.destroy()
@@ -904,19 +904,19 @@ class ImpactMainWindow(tk.Tk):
             self.AdvancedSet = ImpactZSet.AdvancedSetFrame(self,self.AccKernel)
         else:
             print('Cannot find kernel: '+self.AccKernel)
-                    
+
     def makeAdvancedPlot(self):
         try:
             self.AdvancedPlot.destroy()
         except:
             pass
         if self.AccKernel=='ImpactT':
-            self.AdvancedPlot = ImpactTPlot.AdvancedPlotControlFrame(self)  
+            self.AdvancedPlot = ImpactTPlot.AdvancedPlotControlFrame(self)
         elif self.AccKernel=='ImpactZ':
             self.AdvancedPlot = ImpactZPlot.AdvancedPlotControlFrame(self)
         else:
             print('Cannot find kernel: '+self.AccKernel)
-            
+
     def thread_it(self,func):
         self.button_run['state']='disabled'
         self.run_lock.acquire()
@@ -925,7 +925,7 @@ class ImpactMainWindow(tk.Tk):
         ImpactThread.start()
         self.run_lock.release()
         self.button_run['state']='normal'
-        
+
     def startImpact(self):
         print("Start " + self.AccKernel)
         if self.AccKernel=='ImpactT':
@@ -935,10 +935,10 @@ class ImpactMainWindow(tk.Tk):
                 print("Error: cannot get to the dictionary" + self.entry_dic.get())
                 return
             np = self.save('ImpactT.in')
-            
+
             #ImpactExe = os.path.join(sys.path[0],'src',self.IMPACT_T_EXE)
             ImpactExe = self.IMPACT_T_EXE.get()
-            
+
             if np==1:
                 cmd = ImpactExe
             elif np>1:
@@ -955,7 +955,7 @@ class ImpactMainWindow(tk.Tk):
                 print("Error: cannot get to the dictionary" + self.entry_dic.get())
                 return
             np = self.save('ImpactZ.in')
-            
+
             #ImpactExe = os.path.join(sys.path[0],'src',_IMPACT_Z_NAME)
             ImpactExe = self.IMPACT_Z_EXE.get()
             if np==1:
@@ -969,7 +969,7 @@ class ImpactMainWindow(tk.Tk):
             p.stdout.close()
         else:
             print('Cannot find kernel: '+self.AccKernel)
-  
+
     def validate(self, action, index, value_if_allowed,
                        prior_value, text, validation_type, trigger_type, widget_name):
         for word in text:
@@ -983,7 +983,7 @@ class ImpactMainWindow(tk.Tk):
             else:
                 self.bell()
                 return False
-            
+
     def save(self,fileName):
         if os.path.isfile(fileName) == True and os.path.isfile(fileName+'.old') == False:
             copyfile(fileName,fileName+'.old')
@@ -1001,14 +1001,14 @@ class ImpactMainWindow(tk.Tk):
             print(( "  ERROR! Can't save file as '" + fileName + "'"))
             return False
 
-        ImpactInput.writelines(["!This is the input file for ImpactT. It is generated by GUI.\n", 
+        ImpactInput.writelines(["!This is the input file for ImpactT. It is generated by GUI.\n",
                                  "!If you meet any bug, please contact jqiang@lbl.gov\n\n"])
-        
+
         ImpactInput.write( str(int(self.entry_noc1.get()))+' '
                           +str(int(self.entry_noc2.get()))+' '
                           +('5\n' if self.GPUflag.get() else '0\n'))
         np = int(self.entry_noc1.get())*int(self.entry_noc2.get())
-        
+
         ImpactInput.write( str(float(   self.entry_dt.get()))+' '
                           +str(int(     self.entry_Nstep.get())) + ' '
                           +str(int(     self.Nbunch.get()))+'\n')
@@ -1058,7 +1058,7 @@ class ImpactMainWindow(tk.Tk):
                           +str(float(self.entry_frq.get()))+' '
                           +str(float(self.Tinitial.get()))
                           +'\n\n')
-        
+
         ImpactInput.write('!===========LATTICE===========\n')
         lattice = self.lattice.getHide().splitlines()
         print(lattice)
@@ -1067,28 +1067,28 @@ class ImpactMainWindow(tk.Tk):
                 ImpactInput.write(line+'\n')
         ImpactInput.close()
         return np
-    
+
     def saveImpactZ(self,fileName):
         try:
             ImpactInput = open(fileName,'w')
         except:
             print(( "  ERROR! Can't save file as '" + fileName + "'"))
-            return False    
+            return False
 
-        ImpactInput.writelines(["!This is the input file for ImpactZ. It is generated by GUI.\n", 
+        ImpactInput.writelines(["!This is the input file for ImpactZ. It is generated by GUI.\n",
                                 "!If you meet any bug about the GUI, please contact jqiang@lbl.gov\n\n"])
-        
+
         ImpactInput.write( str(int(self.entry_noc1.get()))+' '
                           +str(int(self.entry_noc2.get()))+' '
                           +('5\n' if self.GPUflag.get() else '0\n'))
         np = int(self.entry_noc1.get())*int(self.entry_noc2.get())
-        
+
         ImpactInput.write(str(int(              self.Dim.get()))+' '+
                           str(int(float(        self.entry_Np.get())))+' '+
                           INTEGRATOR_TYPE[      self.Flagmap.get()] +' '+
                           str(int(float(        self.Flagerr.get()))) +' '+
                           OUTPUT_Z_TYPE[        self.FlagOutput_Z.get()]+ '\n')
-        
+
         ImpactInput.write( str(int(     self.entry_Ngx.get()))+' '
                           +str(int(     self.entry_Ngy.get()))+' '
                           +str(int(     self.entry_Ngz.get()))+' '
@@ -1096,7 +1096,7 @@ class ImpactMainWindow(tk.Tk):
                           +str(float(   self.Xrad.get()))+' '
                           +str(float(   self.Yrad.get()))+' '
                           +str(float(   self.ZperiodSize.get()))+'\n')
-        
+
         if self.distType.get() == 'Other':
             ImpactInput.write(self.distTypeNumb.get()    +' '+
                           str(int(float(self.FlagRestart.get())))   +' '+
@@ -1108,7 +1108,7 @@ class ImpactMainWindow(tk.Tk):
                           str(int(float(self.FlagSubcycle.get())))  +' '+
                           str(int(float(self.Nbunch.get())))  +'\n')
 
-        
+
         ImpactInput.write(self.NpList.get()+ '\n')
         ImpactInput.write(self.CurrentList.get()+ '\n')
         ImpactInput.write(self.SchargeList.get()+ '\n')
@@ -1117,7 +1117,7 @@ class ImpactMainWindow(tk.Tk):
             for column in range(7):
                 ImpactInput.write(str(float(self.string_sigma[row][column].get()))+' ')
             ImpactInput.write('\n')
-        
+
         ImpactInput.write(str(float(self.entry_cur.get()))+' '
                           +str(float(self.entry_Ek.get()))+' '
                           +self.ptcMass.get()     + ' '
@@ -1125,7 +1125,7 @@ class ImpactMainWindow(tk.Tk):
                           +str(float(self.entry_frq.get()))+' '
                           +str(float(self.Tinitial.get()))
                           +'\n\n')
-        
+
         ImpactInput.write('!===========LATTICE===========\n')
         lattice = self.lattice.getHide().splitlines()
         print(lattice)
@@ -1136,9 +1136,9 @@ class ImpactMainWindow(tk.Tk):
         #ImpactInput.write('0.1  5 20 2 7.5 7.5 0.0 6.0d-3 /\n\n\n')
         ImpactInput.close()
         return np
-    
+
     def load(self,inputFileName):
-        
+
         if self.AccKernel=='ImpactT':
             self.loadImpactT(inputFileName)
         elif self.AccKernel=='ImpactZ':
@@ -1171,7 +1171,7 @@ class ImpactMainWindow(tk.Tk):
         self.entry_Nstep.delete(0,tk.END)
         self.entry_Nstep.insert(0, dataList[1][1])
         self.Nbunch.set(dataList[1][2])
-              
+
         '''Particle'''
 
         self.Dim.set(dataList[2][0])
@@ -1180,15 +1180,15 @@ class ImpactMainWindow(tk.Tk):
 
         #self.Flagmap.set(1)
         self.Flagerr.set(0 if int(dataList[2][3])==0 else 1)
-        
+
         invermap = dict(map(lambda t:(t[1],t[0]), DIAGNOSTIC_TYPE.items()))
         if dataList[2][4] not in ['1','2','3']:
             dataList[2][4] = '3'
         self.Flagdiag.set(invermap[dataList[2][4]])
-        
+
         self.Flagimag.set(0 if int(dataList[2][5])==0 else 1)
         self.Zimage.set(dataList[2][6])
-        
+
         '''Grid'''
         self.entry_Ngx.delete(0,tk.END)
         self.entry_Ngx.insert(0, dataList[3][0])
@@ -1196,14 +1196,14 @@ class ImpactMainWindow(tk.Tk):
         self.entry_Ngy.insert(0, dataList[3][1])
         self.entry_Ngz.delete(0,tk.END)
         self.entry_Ngz.insert(0, dataList[3][2])
-        
+
         invermap = dict(map(lambda t:(t[1],t[0]), BOUNDARY_TYPE.items()))
         self.Flagbc.set(invermap[dataList[3][3]])
-        
+
         self.Xrad.set(dataList[3][4])
         self.Yrad.set(dataList[3][5])
         self.Zrad.set(dataList[3][6])
-        
+
         '''Distribution'''
         invermap = dict(map(lambda t:(t[1],t[0]), DISTRIBUTION_T_TYPE.items()))
         try:
@@ -1224,7 +1224,7 @@ class ImpactMainWindow(tk.Tk):
         for row in range(3):
             for column in range(7):
                 self.string_sigma[row][column].set(dataList[5+row][column])
-        
+
         '''Particle Type'''
         invermap = dict(map(lambda t:(t[1],t[0]), PARTICLE_TYPE.items()))
         ptcFound = 0
@@ -1242,21 +1242,21 @@ class ImpactMainWindow(tk.Tk):
             self.ptcTypeComx.set('Other')
         self.ptcMass    .set(dataList[8][2])
         self.ptcCharge  .set(dataList[8][3])
-         
+
         """Current"""
         self.entry_cur.delete(0, tk.END)
         self.entry_cur.insert(0, dataList[8][0])
-        
+
         """Energy"""
         self.entry_Ek.delete(0, tk.END)
         self.entry_Ek.insert(0, dataList[8][1])
-        
+
         """Frequency"""
         self.entry_frq.delete(0, tk.END)
         self.entry_frq.insert(0, dataList[8][4])
-        
-        self.Tinitial.set(dataList[8][5]) 
-        
+
+        self.Tinitial.set(dataList[8][5])
+
         """Lattice"""
         self.lattice.latticeTextHide.delete(0.0, tk.END)
         for lineSet in dataList[9:]:
@@ -1264,10 +1264,10 @@ class ImpactMainWindow(tk.Tk):
                 self.lattice.latticeTextHide.insert(tk.END, word + ' ')
             self.lattice.latticeTextHide.insert(tk.END,'\n')
         self.lattice.update()
-        
+
     def loadImpactZ(self,inputFileName):
         dataList = ImpactFile.conciseReadInput(inputFileName)
-        
+
         if dataList ==False:
             return
         rowtemp=0
@@ -1281,7 +1281,7 @@ class ImpactMainWindow(tk.Tk):
         except:
             self.GPUflag.set(0)
         rowtemp+=1
-              
+
         '''Particle'''
         self.Dim.set(dataList[rowtemp][0])
         self.entry_Np.delete(0,tk.END)
@@ -1289,13 +1289,13 @@ class ImpactMainWindow(tk.Tk):
 
         invermap = dict(map(lambda t:(t[1],t[0]), INTEGRATOR_TYPE.items()))
         self.Flagmap.set(invermap[dataList[rowtemp][2]])
-        
+
         self.Flagerr.set(0 if int(dataList[rowtemp][3])==0 else 1)
-        
+
         invermap = dict(map(lambda t:(t[1],t[0]), OUTPUT_Z_TYPE.items()))
         self.Flagdiag.set(invermap[dataList[rowtemp][4]])
         rowtemp+=1
-        
+
         '''Grid'''
         self.entry_Ngx.delete(0,tk.END)
         self.entry_Ngx.insert(0, dataList[rowtemp][0])
@@ -1303,18 +1303,18 @@ class ImpactMainWindow(tk.Tk):
         self.entry_Ngy.insert(0, dataList[rowtemp][1])
         self.entry_Ngz.delete(0,tk.END)
         self.entry_Ngz.insert(0, dataList[rowtemp][2])
-        
+
         invermap = dict(map(lambda t:(t[1],t[0]), BOUNDARY_TYPE.items()))
         self.Flagbc.set(invermap[dataList[rowtemp][3]])
-        
+
         self.Xrad.set(str(float(dataList[rowtemp][4])))
         self.Yrad.set(str(float(dataList[rowtemp][5])))
         self.ZperiodSize.set(str(float(dataList[rowtemp][6])))
         rowtemp+=1
-        
+
         '''Distribution'''
         invermap = dict(map(lambda t:(t[1],t[0]), DISTRIBUTION_Z_TYPE.items()))
-        
+
         try:
             if dataList[rowtemp][0] in invermap.keys():
                 self.distTypeComx.set(invermap[dataList[rowtemp][0]])
@@ -1329,15 +1329,15 @@ class ImpactMainWindow(tk.Tk):
         self.FlagSubcycle.set(0 if int(dataList[rowtemp][2])==0 else 1)
         self.Nbunch.set(dataList[rowtemp][3])
         rowtemp+=1
-        
+
         '''Multiple Charge State'''
-        self.NpList.set(' '.join(dataList[rowtemp])) 
+        self.NpList.set(' '.join(dataList[rowtemp]))
         rowtemp+=1
-        self.CurrentList.set(' '.join(dataList[rowtemp])) 
+        self.CurrentList.set(' '.join(dataList[rowtemp]))
         rowtemp+=1
-        self.SchargeList.set(' '.join(dataList[rowtemp])) 
+        self.SchargeList.set(' '.join(dataList[rowtemp]))
         rowtemp+=1
-        
+
         '''Twiss'''
         for row in range(3):
             for column in range(7):
@@ -1361,25 +1361,25 @@ class ImpactMainWindow(tk.Tk):
                 pass
         if ptcFound==0:
             self.ptcTypeComx.set('Other')
-        
+
         self.ptcMass    .set(dataList[rowtemp][2])
         self.ptcCharge  .set(dataList[rowtemp][3])
         #print(rowtemp,dataList[rowtemp])
-            
+
         """Current"""
         self.entry_cur.delete(0, tk.END)
         self.entry_cur.insert(0, dataList[rowtemp][0])
-        
+
         """Energy"""
         self.entry_Ek.delete(0, tk.END)
         self.entry_Ek.insert(0, dataList[rowtemp][1])
-        
+
         """Frequency"""
         self.entry_frq.delete(0, tk.END)
         self.entry_frq.insert(0, dataList[rowtemp][4])
-        
-        self.Tinitial.set(dataList[rowtemp][5]) 
-        
+
+        self.Tinitial.set(dataList[rowtemp][5])
+
         rowtemp+=1
         """Lattice"""
         self.lattice.latticeTextHide.delete(0.0, tk.END)
@@ -1389,8 +1389,8 @@ class ImpactMainWindow(tk.Tk):
             self.lattice.latticeTextHide.insert(tk.END,'\n')
         self.lattice.update()
 
-        
-        
+
+
 class PlotControlFrame(tk.Frame):
     """Output"""
     def __init__(self, master=None, cnf={}, **kw):
@@ -1398,12 +1398,12 @@ class PlotControlFrame(tk.Frame):
         """Plot Control"""
         self.frame_plotButton = tk.Frame(self, height =_height/5, width = _width)
         self.frame_plotButton.grid(column=0, row = 0, pady=5 ,padx=10, sticky="e")
-        
+
         self.frame_se = tk.Frame(self.frame_plotButton)
         self.frame_se.pack(side='left')
         self.frame_radio = tk.Frame(self.frame_se)
         self.frame_radio.pack(side='left')
-        
+
         self.plotDirct = tk.IntVar()
         self.plotDirct.set(0)
         self.frame_radio.x = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
@@ -1415,42 +1415,42 @@ class PlotControlFrame(tk.Frame):
         self.frame_radio.z = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
                                            text="Z", value=2)
         self.frame_radio.z.pack(side='left')
-        
+
         self.plotTypeComx = tk.StringVar(self.frame_se,'Rms size')
         self.plotType = ttk.Combobox(self.frame_se,text=self.plotTypeComx,
                                      values=list(ImpactMainWindow.PLOTTYPE.keys()))
         self.plotType.pack(side = 'left')
-        
+
         self.plot = tk.Button(self.frame_plotButton,text='plot',command=self.makePlot)
         self.plot.pack(fill = 'both',expand =1,side = 'left',padx=10)
-        
+
         self.t = ttk.Separator(self, orient=tk.HORIZONTAL).grid(column=0, row = 1, sticky="we")
 
-           
+
         self.frame2 = tk.Frame(self, height =_height/5, width = _width)
         self.frame2.grid(column=0, row = 2, pady=5 ,padx=10, sticky="we")
-        
+
         self.ParticlePlot = tk.Button(self.frame2,text='Phase Space Plot',
                                command = self.makeParticlePlot)
         self.ParticlePlot.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.button_AdvancedPlot = tk.Button(self.frame2,text='Advanced Plot',
                                command = self.makeAdvancedPlot)
         self.button_AdvancedPlot.pack(fill = 'both',expand =1,side = 'left')
-    
+
     def makePlot(self):
         print((self.plotType))
-        
+
         PlotFileName='fort.'+str(self.plotDirct.get()+24)
         yx=ImpactMainWindow.PLOTTYPE[self.plotType.get()]
         yl=yx if self.plotDirct.get()!=2 else yx-1
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ImpactTPlot.PlotFrame(plotWindow,PlotFileName,0,yl)
         l.pack()
-        
+
     def makeParticlePlot(self):
         print((self.plotType))
         filename = filedialog.askopenfilename(parent=self)
@@ -1459,111 +1459,111 @@ class PlotControlFrame(tk.Frame):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Phase Space Plot')
-        
+
         l=ImpactTPlot.PhaseSpaceFrame(plotWindow,filename)
-        l.pack()            
+        l.pack()
     def makeAdvancedPlot(self):
         try:
             self.AdvancedPlot.destroy()
         except:
             pass
         if self.AccKernel=='ImpactT':
-            self.AdvancedPlot = ImpactTPlot.AdvancedPlotControlFrame(self)  
+            self.AdvancedPlot = ImpactTPlot.AdvancedPlotControlFrame(self)
 
 class startWindow(tk.Toplevel):
     def __init__(self, master, cnf={}, **kw):
         tk.Toplevel.__init__(self, master, cnf, **kw)
         self.title('Start')
         self.focus_set()
-        
+
         self.frame = tk.Frame(self,width = 300,height = 200)
         self.frame.pack(fill = 'both',expand =1,side = 'top')
-        LARGE_FONT= ("Helvetica", 20,'italic')     
-        
-        
+        LARGE_FONT= ("Helvetica", 20,'italic')
+
+
         self.button_ImpactT = tk.Button(self.frame,text='ImpactT',font = LARGE_FONT,
                                         command = lambda: self.startImpactT(master))
         self.button_ImpactT.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.button_ImpactT.bind("<Enter>", lambda event, h=self.button_ImpactT: h.configure(bg="#00CD00"))
         self.button_ImpactT.bind("<Leave>", lambda event, h=self.button_ImpactT: h.configure(bg="#FFFFFF"))
 
-        
+
         self.button_ImpactZ = tk.Button(self.frame,text='ImpactZ',font = LARGE_FONT,
                                         command = lambda: self.startImpactZ(master))
         self.button_ImpactZ.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.button_ImpactZ.bind("<Enter>", lambda event, h=self.button_ImpactZ: h.configure(bg="#00CD00"))
         self.button_ImpactZ.bind("<Leave>", lambda event, h=self.button_ImpactZ: h.configure(bg="#FFFFFF"))
-        
+
         self.button_close = tk.Button(self,text='QUIT',font = LARGE_FONT,
                                         command = lambda: master.quit())
         self.button_close.pack(fill = 'both',expand =0,side = 'bottom')
-        
+
         self.button_close.bind("<Enter>", lambda event, h=self.button_close: h.configure(bg="#00CD00"))
         self.button_close.bind("<Leave>", lambda event, h=self.button_close: h.configure(bg="#FFFFFF"))
-        
+
         self.protocol('WM_DELETE_WINDOW', lambda: master.quit())
-        
-        
+
+
     def startImpactT(self,master):
         master.switchToImpactT()
         master.deiconify()
         self.resize(master)
         self.destroy()
-        
+
     def startImpactZ(self,master):
         master.switchToImpactZ()
         master.deiconify()
         self.resize(master)
         self.destroy()
-        
+
     def closeWindow(self,master):
         master.quit()
-        
+
     def resize(self,master):
         w  = master.winwidth
         h  = master.winheight
 
-        
+
         x = master.winPosX
         y = master.winPosY
         print(w,h,x,y)
         master.geometry('%dx%d+%d+%d' % (w, h, x, y))
-        
-        
+
+
 class MyMenu():
     def __init__(self, root):
 
         self.menubar = tk.Menu(root)
-        
+
         filemenu = tk.Menu(self.menubar, tearoff=0)
         filemenu.add_command(label="Load", command=lambda: self.file_open(root))
         filemenu.add_command(label="Save", command=self.file_save)
         filemenu.add_separator()
         filemenu.add_command(label="Exit", command=root.exit)
-        
+
         controlMenu = tk.Menu(self.menubar, tearoff=0)
         controlMenu.add_command(label="Switch to ImpactT", command=lambda: self.control_switchToImpactT(root))
         controlMenu.add_command(label="Switch to ImpactZ", command=lambda: self.control_switchToImpactZ(root))
 
-        
+
         helpmenu = tk.Menu(self.menubar, tearoff=0)
         helpmenu.add_command(label="Help", command=self.help_help)
         helpmenu.add_command(label="About", command=self.help_about)
         self.menubar.add_cascade(label="File", menu=filemenu)
         self.menubar.add_cascade(label="Switch", menu=controlMenu)
         self.menubar.add_cascade(label="Help", menu=helpmenu)
-        
+
         root.config(menu=self.menubar)
-      
+
     def file_new(self):
         messagebox.showinfo('about', 'GUI authors: Zhicong Liu and Ji Qiang \n verion 1.0 \n jqiang@lbl.gov ')
         pass
-          
+
     def file_open(self,root):
         filename = filedialog.askopenfilename(parent=root)
         if filename=='':
@@ -1577,33 +1577,33 @@ class MyMenu():
             return
         root.save(filename)
         pass
-        
+
     def control_switchToImpactT(self,root):
         root.switchToImpactT()
         root.bell()
         pass
-    
+
     def control_switchToImpactZ(self,root):
         root.switchToImpactZ()
         root.bell()
         pass
-        
+
     def edit_copy(self):
         messagebox.showinfo('about', 'GUI authors: Zhicong Liu, Ji Qiang \n verion 1.0 \n jqiang@lbl.gov ')
         pass
-        
+
     def edit_paste(self):
         messagebox.showinfo('about', 'GUI authors: Zhicong Liu, Ji Qiang \n verion 1.0 \n jqiang@lbl.gov ')
         pass
-    
+
     def help_help(self):
         messagebox.showinfo('Help', 'Please refer "ImpactTv1.8.pdf" at this folder ')
         pass
-    
+
     def help_about(self):
         messagebox.showinfo('About', ' Version 1.0 \n\n Kernel author: Ji Qiang \n jqiang@lbl.gov \n\n GUI authors: Zhicong Liu, Ji Qiang \n jqiang@lbl.gov ')
         pass
-        
+
 def resource_path(relative_path):
     """ Get absolute path to resource, works for dev and for PyInstaller """
     try:

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -948,7 +948,11 @@ class PlotMultiBunchBaseFrame(PlotBaseFrame):
         self.offset_label = tk.Label(self.option_frame, text='z offset (mm):')
         self.offset_label.pack(side='left')
         self.offset_box = tk.Entry(self.option_frame, width=6)
-        self.offset_box.insert(0, '0')
+        try:
+            z_offset = MultiBunchPlot.get_z_offset()
+        except:
+            z_offset = 0
+        self.offset_box.insert(0, str(z_offset*1e3))
         self.offset_box.pack(fill='both', expand=1, side='left')
     def get_from_bunch(self):
         """Get branch selected in options frame."""
@@ -970,7 +974,11 @@ class PlotMultiBunchBaseFrame(PlotBaseFrame):
         if hasattr(self, "offset_box"):
             return float(self.offset_box.get())/1000
         else:
-            return None
+            try:
+                z_offset = MultiBunchPlot.get_z_offset()
+            except:
+                z_offset = None
+            return z_offset
 
 class PlotMBBeamSizeFrame(PlotMultiBunchBaseFrame):
     """Frame to plot rms beam sizes for selected bunches."""

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -18,7 +18,7 @@ from scipy.stats import gaussian_kde
 import numpy as np
 
 
-import ParticlePlot, SlicePlot
+import ParticlePlot, SlicePlot, MultiBunchPlot
 _height=300
 _width =200
 
@@ -32,6 +32,8 @@ IMPACT_T_ADVANCED_PLOT_TYPE= {'Centriod location (mm)'    :2,
 IMPACT_T_SciFormatter = FormatStrFormatter('%2.1E')
 IMPACT_T_sciMaxLimit  = 99999 *2
 IMPACT_T_sciMinLimit  = 0.0001*2
+IMPACT_T_initial_slice = 40
+IMPACT_T_final_slice   = 50
 
 class AdvancedPlotControlFrame(tk.Toplevel):
     """Output"""
@@ -157,6 +159,51 @@ class AdvancedPlotControlFrame(tk.Toplevel):
 
         rowN+=1
 
+        self.t = (ttk.Separator(self.frame2, orient=tk.HORIZONTAL)
+                     .grid(row=rowN, column=0, columnspan=2, sticky="we"))
+        rowN += 1
+        self.label_MB = tk.Label(self.frame2, text='Multi-bunch plots')
+        self.label_MB.grid(row=rowN, column=0, columnspan=2, sticky="we")
+        rowN += 1
+        self.button_MBBeamSizePlot = tk.Button(self.frame2,
+                                               text='Beam size',
+                                               command=self.MBBeamSizePlot)
+        self.button_MBBeamSizePlot.grid(row=rowN, column=0, columnspan=1,
+                                        padx=5, pady=1, sticky="nswe")
+        self.button_MBBunchCountPlot = tk.Button(self.frame2,
+                                                 text='Bunch count',
+                                                 command=self.MBBunchCountPlot)
+        self.button_MBBunchCountPlot.grid(row=rowN, column=1, columnspan=1,
+                                          padx=5, pady=1, sticky="nswe")
+        rowN += 1
+        self.button_MBEmittancePlot = tk.Button(self.frame2,
+                                                text='Emittance',
+                                                command=self.MBEmittancePlot)
+        self.button_MBEmittancePlot.grid(row=rowN, column=0, columnspan=1,
+                                         padx=5, pady=1, sticky="nswe")
+        self.button_MBEmitGrowthPlot = tk.Button(self.frame2,
+                                                 text='Emittance growth',
+                                                 command=self.MBEmitGrowthPlot)
+        self.button_MBEmitGrowthPlot.grid(row=rowN, column=1, columnspan=1,
+                                          padx=5, pady=1, sticky="nswe")
+        rowN += 1
+        self.button_MBEnergyPlot = tk.Button(self.frame2,
+                                             text='Energy',
+                                             command=self.MBEnergyPlot)
+        self.button_MBEnergyPlot.grid(row=rowN, column=0, columnspan=1,
+                                      padx=5, pady=1, sticky="nswe")
+        self.button_MBTotalEnergyPlot = tk.Button(self.frame2,
+                                                  text='Total energy',
+                                                  command=self.MBTotalEnergyPlot)
+        self.button_MBTotalEnergyPlot.grid(row=rowN, column=1, columnspan=1,
+                                           padx=5, pady=1, sticky="nswe")
+        rowN += 1
+        self.button_MBPhaseSpacePlot = tk.Button(self.frame2,
+                                                 text='Phase space',
+                                                 command=self.MBPhaseSpacePlot)
+        self.button_MBPhaseSpacePlot.grid(row=rowN, column=0, columnspan=2,
+                                          padx=5, pady=1, sticky="nswe")
+        rowN += 1
 
 
     def overallPlot(self):
@@ -339,6 +386,55 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         l=Plot4orderFrame(plotWindow,filename)
         l.pack()
 
+    def MBBeamSizePlot(self):
+        print('Multi-bunch beam size plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch beam size plot')
+        l = PlotMBBeamSizeFrame(plotWindow)
+        l.pack()
+
+    def MBBunchCountPlot(self):
+        print('Multi-bunch bunch count plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch bunch count plot')
+        l = PlotMBBunchCountFrame(plotWindow)
+        l.pack()
+
+    def MBEmittancePlot(self):
+        print('Multi-bunch emittance plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch emittance plot')
+        l = PlotMBEmittanceFrame(plotWindow)
+        l.pack()
+
+    def MBEmitGrowthPlot(self):
+        print('Multi-bunch emittance growth plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch emittance growth plot')
+        l = PlotMBEmittanceGrowthFrame(plotWindow)
+        l.pack()
+
+    def MBPhaseSpacePlot(self):
+        print('Multi-bunch phase space plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch phase space plot')
+        l = PlotMBPhaseSpaceFrame(plotWindow)
+        l.pack()
+
+    def MBEnergyPlot(self):
+        print('Multi-bunch energy spectra plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch energy spectra plot')
+        l = PlotMBEnergyFrame(plotWindow)
+        l.pack()
+
+    def MBTotalEnergyPlot(self):
+        print('Multi-bunch total energy spectrum plot')
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Multi-bunch total energy spectrum plot')
+        l = PlotMBTotalEnergyFrame(plotWindow)
+        l.pack()
+
 class PlotBaseFrame(tk.Frame):
     """Basic plot object that other objects inherit from"""
     def __init__(self, parent, per_bunch=True):
@@ -441,6 +537,8 @@ class PlotBaseFrame(tk.Frame):
             return [tcol, 'time (s)']
         else:
             return [zcol, 'z direction (m)']
+    def plot(self):
+        raise NotImplementedError()
 
 class PlotFrame(PlotBaseFrame):
     def __init__(self, parent, PlotFileName, yl, labelY, per_bunch=True):
@@ -806,3 +904,259 @@ class Plot4orderFrame(PlotHighOrderBaseFrame):
     def get_yaxis_parameters(self):
         ycol, ylabel = PlotHighOrderBaseFrame.get_yaxis_parameters(self)
         return [ycol, 'Square square root of 4th moment of ' + ylabel]
+
+class PlotMultiBunchBaseFrame(PlotBaseFrame):
+    """Base class for frames that combine data from multiple bunches."""
+    def __init__(self, parent):
+        PlotBaseFrame.__init__(self, parent, per_bunch=True)
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
+        self.plot()
+    def create_bunch_selector(self, Nbunch, per_bunch=True):
+        """Add selector (override base class, give 'from' and 'to' bunches)."""
+        if per_bunch and Nbunch > 1:
+            self.from_bunch_list = list(range(1, Nbunch + 1))
+            self.from_bunch_default = tk.StringVar(self.option_frame, '1')
+            self.from_bunch_label = tk.Label(self.option_frame,
+                                             text='Bunches from:')
+            self.from_bunch_label.pack(side='left')
+            self.from_bunch_select = ttk.Combobox(self.option_frame,
+                                                  text=self.from_bunch_default,
+                                                  width=6,
+                                                  values=self.from_bunch_list)
+            self.from_bunch_select.pack(fill='both', expand=1, side='left')
+            self.to_bunch_list = list(range(1, Nbunch + 1))
+            self.to_bunch_default = tk.StringVar(self.option_frame,
+                                                 str(self.Nbunch))
+            self.to_bunch_label = tk.Label(self.option_frame, text='to:')
+            self.to_bunch_label.pack(side='left')
+            self.to_bunch_select = ttk.Combobox(self.option_frame,
+                                                text=self.to_bunch_default,
+                                                width=6,
+                                                values=self.to_bunch_list)
+            self.to_bunch_select.pack(fill='both', expand=1, side='left')
+    def get_from_bunch(self):
+        """Get branch selected in options frame."""
+        if hasattr(self, "from_bunch_select"):
+            return int(self.from_bunch_select.get())
+        else:
+            return 1
+    def get_to_bunch(self):
+        """Get branch selected in options frame."""
+        if hasattr(self, "to_bunch_select"):
+            return int(self.to_bunch_select.get())
+        else:
+            return self.Nbunch
+    def get_bunch_list(self):
+        """Find which bunches are selected in the option frame."""
+        return list(range(self.get_from_bunch(), self.get_to_bunch()+1))
+
+class PlotMBBeamSizeFrame(PlotMultiBunchBaseFrame):
+    """Frame to plot rms beam sizes for selected bunches."""
+    def __init__(self, parent):
+        PlotMultiBunchBaseFrame.__init__(self, parent)
+    def plot(self):
+        """Plot rms beam size and compare with experimental results."""
+        try:
+            experimental_results = MultiBunchPlot.load_experimental_results()
+        except FileNotFoundError as err:
+            print(f'Experimental data file not found: {err}')
+            print('Continuing without experimental data.')
+            experimental_results = None
+        bunch_list = self.get_bunch_list()
+        xdata, ydata = MultiBunchPlot.load_statistics_data(bunch_list)
+        # TODO: Can we calculate rdata from xdata and ydata?
+        self.subfig.cla()
+        MultiBunchPlot.plot_beam_size(self.subfig.axes, xdata, bunch_list,
+                                      xaxis=self.get_selected_xaxis(),
+                                      experiment_data=experimental_results)
+        self.canvas.draw()
+
+class PlotMBBunchCountFrame(PlotMultiBunchBaseFrame):
+    """Frame to plot bunch counts for selected bunches."""
+    def __init__(self, parent):
+        PlotMultiBunchBaseFrame.__init__(self, parent)
+    def plot(self):
+        """Plot bunch counts up to the selected max bunch."""
+        self.subfig.cla()
+        self.data = MultiBunchPlot.load_bunch_count_data()
+        MultiBunchPlot.plot_bunch_count(self.subfig, self.data,
+                                        self.get_bunch_list(),
+                                        xaxis=self.get_selected_xaxis())
+        self.canvas.draw()
+
+class PlotMBEmittanceFrame(PlotMultiBunchBaseFrame):
+    """Frame to plot emittance for selected bunches together."""
+    def __init__(self, parent):
+        PlotMultiBunchBaseFrame.__init__(self, parent)
+    def plot(self):
+        """Plot average of x and y emittance for selected bunches."""
+        bunch_list = self.get_bunch_list()
+        xdata, ydata = MultiBunchPlot.load_statistics_data(bunch_list)
+        self.subfig.cla()
+        MultiBunchPlot.plot_emittance(self.subfig.axes,
+                                      xdata, ydata, bunch_list,
+                                      xaxis=self.get_selected_xaxis())
+        self.canvas.draw()
+
+class PlotMBEmittanceGrowthFrame(PlotMultiBunchBaseFrame):
+    """Frame to plot emittance growth for selected bunches together."""
+    def __init__(self, parent):
+        PlotMultiBunchBaseFrame.__init__(self, parent)
+    def plot(self):
+        """Plot growth of average x and y emittance for selected bunches."""
+        bunch_list = self.get_bunch_list()
+        xdata, ydata = MultiBunchPlot.load_statistics_data(bunch_list)
+        self.subfig.cla()
+        MultiBunchPlot.plot_emittance_growth(self.subfig.axes,
+                                             xdata, ydata, bunch_list,
+                                             xaxis=self.get_selected_xaxis())
+        self.canvas.draw()
+
+class PlotMultiBunchParticleBaseFrame(PlotMultiBunchBaseFrame):
+    """Base class for multi-bunch plots based on particle output files."""
+    def __init__(self, parent):
+        PlotBaseFrame.__init__(self, parent, per_bunch=True)
+        self.last_filenumber = 0
+        self.last_bunch_count = 0
+        self.plot()
+    def create_option_frame(self, Nbunch, per_bunch=True):
+        """Add options (override base class)."""
+        self.option_frame = tk.Frame(self)
+        self.option_frame.pack()
+        self.create_slice_selector()
+        self.create_bunch_selector(Nbunch)
+        self.create_bins_box()
+        self.create_plot_button()
+    def create_slice_selector(self):
+        """Add selector for which slice or BPM output to plot."""
+        self.slice_list = self.get_slice_list()
+        self.slice_default = tk.StringVar(self.option_frame, 'Initial')
+        self.slice_label = tk.Label(self.option_frame,
+                                    text='Select phase space position: ')
+        self.slice_label.pack(fill='both', expand=1, side='left')
+        self.slice_select = ttk.Combobox(self.option_frame,
+                                         text=self.slice_default,
+                                         width=6,
+                                         values=list(self.slice_list))
+        self.slice_select.pack(fill='both', expand=1, side='left')
+    def create_bins_box(self):
+        """Add text box to set number of bins for plot sampling."""
+        self.bins_label = tk.Label(self.option_frame, text='Bins: ')
+        self.bins_label.pack(fill='both', expand=1, side='left')
+        self.bins = tk.Entry(self.option_frame, width=5)
+        self.bins.insert(0, '100')
+        self.bins.pack(fill='both', expand=1, side='left')
+    def get_slice_list(self):
+        """Get list of available phase space slices, including BPMs."""
+        lattice = MultiBunchPlot.get_lattice()
+        bpm_list = MultiBunchPlot.get_bpms(lattice)
+        slice_list = {'Initial': IMPACT_T_initial_slice}
+        slice_list.update(bpm_list)
+        slice_list['Final'] = IMPACT_T_final_slice
+        return slice_list
+    def get_filenumber(self):
+        """Get the file number of the selected slice for plotting."""
+        return self.slice_list[self.slice_select.get()]
+    def get_bins(self):
+        """Get the selected number of bins for plot sampling."""
+        return int(self.bins.get())
+    def get_title(self, filenumber):
+        """Generate the plot title for a particular file number."""
+        raise NotImplementedError()
+    def build_title(self, base_title, filenumber):
+        """Build the plot title from a base string and a file number."""
+        bunch_text = MultiBunchPlot.bunch_text(self.get_bunch_list())
+        if filenumber == IMPACT_T_initial_slice:
+            return f'Initial {base_title} for {bunch_text}'
+        elif filenumber == IMPACT_T_final_slice:
+            return f'Final {base_title} for {bunch_text}'
+        else:
+            matches = [bpm for bpm in self.slice_list
+                       if self.slice_list[bpm] == filenumber]
+            return (f'{base_title} at z = {matches[0]} '.capitalize()
+                    + f'for {bunch_text}')
+    def refresh_data(self):
+        """Reload data (list of all bunch data) when filenumber is changed."""
+        filenumber = self.get_filenumber()
+        if filenumber != self.last_filenumber:
+            full_bunch_list = list(range(1, self.Nbunch+1))
+            self.data = MultiBunchPlot.load_phase_space_data(filenumber,
+                                                             full_bunch_list)
+            self.last_filenumber = filenumber
+    def get_selected_data(self):
+        """Return datasets for only the selected bunches."""
+        self.refresh_data()
+        return [self.data[bunch-1] for bunch in self.get_bunch_list()]
+    def get_combined_data(self):
+        """Return a combined dataset for the selected bunches."""
+        return MultiBunchPlot.combine_phase_space_data(self.get_selected_data())
+
+class PlotMBPhaseSpaceFrame(PlotMultiBunchParticleBaseFrame):
+    """Frame to plot phase spaces for selected bunches together."""
+    def __init__(self, parent):
+        PlotMultiBunchParticleBaseFrame.__init__(self, parent)
+    def create_figure(self):
+        """Create four subplots (override base class)."""
+        self.fig = Figure(figsize=(8,6))
+        self.subfig = []
+        self.subfig.append(self.fig.add_subplot(221))
+        self.subfig.append(self.fig.add_subplot(222))
+        self.subfig.append(self.fig.add_subplot(223))
+        self.subfig.append(self.fig.add_subplot(224))
+        self.axes = np.array([[self.subfig[0], self.subfig[1]],
+                              [self.subfig[2], self.subfig[3]]])
+        for subfig in self.subfig:
+            box = subfig.get_position()
+            subfig.set_position([box.x0*1.1, box.y0*1.1,
+                                 box.width, box.height*0.88])
+    def get_title(self, filenumber):
+        """Generate the plot title for a particular file number."""
+        return self.build_title('phase space', filenumber)
+    def plot(self):
+        """Load and plot phase space data for selected bunches."""
+        for subfig in self.subfig:
+            subfig.cla()
+        MultiBunchPlot.plot_phase_spaces(
+            self.axes,
+            self.get_combined_data(),
+            self.get_bunch_list(),
+            title=self.get_title(self.get_filenumber()),
+            grid_size=self.get_bins())
+        self.canvas.draw()
+
+class PlotMBEnergyFrame(PlotMultiBunchParticleBaseFrame):
+    """Frame to plot energy spectra for selected bunches together."""
+    def __init__(self, parent):
+        PlotMultiBunchParticleBaseFrame.__init__(self, parent)
+    def get_title(self, filenumber):
+        """Generate the plot title for a particular file number."""
+        return self.build_title('energy spectra', filenumber)
+    def plot(self):
+        """Plot energy spectra for selected bunches."""
+        self.subfig.cla()
+        MultiBunchPlot.plot_bunch_energies(
+            self.subfig.axes,
+            self.get_selected_data(),
+            self.get_bunch_list(),
+            title=self.get_title(self.get_filenumber()),
+            bins=self.get_bins())
+        self.canvas.draw()
+
+class PlotMBTotalEnergyFrame(PlotMultiBunchParticleBaseFrame):
+    """Frame to plot total energy spectrum for selected bunches combined."""
+    def __init__(self, parent):
+        PlotMultiBunchParticleBaseFrame.__init__(self, parent)
+    def get_title(self, filenumber):
+        """Generate the plot title for a particular file number."""
+        return self.build_title('energy spectrum', filenumber)
+    def plot(self):
+        """Load and plot total energy spectrum for selected bunches."""
+        self.subfig.cla()
+        MultiBunchPlot.plot_total_energy(
+            self.subfig.axes,
+            self.get_combined_data(),
+            self.get_bunch_list(),
+            title=self.get_title(self.get_filenumber()),
+            bins=self.get_bins())
+        self.canvas.draw()

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -568,9 +568,40 @@ class OverallFrame(tk.Frame):
 class EmitGrowthFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
+
+        self.Nbunch = int(parent.master.master.Nbunch.get())
+        if self.Nbunch > 1:
+            self.create_option_frame(self.Nbunch)
+
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
+
         self.plot()
+    def create_option_frame(self, Nbunch):
+        """Creates a bar at the top to select options of the plot"""
+        self.option_frame = tk.Frame(self)
+        self.option_frame.pack()
+        self.bunch_list = ['All']
+        self.bunch_list.extend(range(1, Nbunch + 1))
+        self.bunch_default = tk.StringVar(self.option_frame, 'All')
+        self.bunch_label = tk.Label(self.option_frame, text="Select bunch: ")
+        self.bunch_label.pack(side='left')
+        self.bunch_select = ttk.Combobox(
+            self.option_frame,
+            text=self.bunch_default,
+            width=6,
+            values=self.bunch_list)
+        self.bunch_select.pack(fill='both', expand=1, side='left')
+        self.plot_button = tk.Button(
+            self.option_frame,
+            text="Plot",
+            foreground="blue",
+            bg="red",
+            font=("Verdana", 12),
+            command=self.plot)
+        self.plot_button.pack(fill='both', expand=1, side='left')
     def plot(self):        
-        fileList        = ['fort.24','fort.25']
+        fileList        = self.get_filelist()
         xdataList       = [2,2]
         ydataList       = [8,8]
         xyLabelList     = ['Z (m)','Avg emit growth in X and Y']
@@ -606,13 +637,28 @@ class EmitGrowthFrame(PlotBaseFrame):
         
         self.subfig.cla()
         self.subfig.plot(x, y, lineType[0], linewidth=2, label='emit.growth')
-        box = self.subfig.get_position()
-        self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
+        
         self.subfig.set_xlabel(xyLabelList[0])
         self.subfig.set_ylabel(xyLabelList[1])
         self.subfig.legend()
         
         self.canvas.draw()
+        
+    def get_default_filelist(self):
+        return ['fort.24', 'fort.25']
+    def get_bunch_filelist(self, bunch):
+        return [f'fort.{bunch*1000+24}', f'fort.{bunch*1000+25}']
+    def get_filelist(self):
+        selected_bunch = self.get_selected_bunch()
+        if selected_bunch == 'All':
+            return self.get_default_filelist()
+        else:
+            return self.get_bunch_filelist(int(selected_bunch))
+    def get_selected_bunch(self):
+        if hasattr(self, "bunch_select"):
+            return self.bunch_select.get()
+        else:
+            return 'All'
         
 class TemperatureFrame(PlotBaseFrame):
     def __init__(self, parent):

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -377,10 +377,10 @@ class PlotFrame(tk.Frame):
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
         
         fig = Figure(figsize=(7,5), dpi=100)
-        subfig = fig.add_subplot(111)
-        subfig.plot(x,y)
-        subfig.set_xlabel('Z (m)')
-        subfig.set_ylabel(labelY)
+        self.subfig = fig.add_subplot(111)
+        self.subfig.plot(x,y)
+        self.subfig.set_xlabel('Z (m)')
+        self.subfig.set_ylabel(labelY)
 
         xMax = np.max(x)
         xMin = np.min(x)
@@ -393,8 +393,8 @@ class PlotFrame(tk.Frame):
         
         #xmajorFormatter = FormatStrFormatter('%2.2E')
         #subfig.yaxis.set_major_formatter(xmajorFormatter)
-        box = subfig.get_position()
-        subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self)
         canvas.draw()
@@ -723,6 +723,6 @@ def axis_format_T(xData,yData,subfig):
     yMax = np.max(yData)
     yMin = np.min(yData)
     if (xMax-xMin)>IMPACT_T_sciMaxLimit or (xMax-xMin)<IMPACT_T_sciMinLimit:
-        subfig.xaxis.set_major_formatter(IMPACT_T_SciFormatter)
+        self.subfig.xaxis.set_major_formatter(IMPACT_T_SciFormatter)
     if (yMax-yMin)>IMPACT_T_sciMaxLimit or (yMax-yMin)<IMPACT_T_sciMinLimit:
-        subfig.yaxis.set_major_formatter(IMPACT_T_SciFormatter)
+        self.subfig.yaxis.set_major_formatter(IMPACT_T_SciFormatter)

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import ttk,filedialog
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 from scipy.stats import gaussian_kde
@@ -344,7 +344,7 @@ class PlotBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -400,7 +400,7 @@ class PlotFrame(tk.Frame):
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        toolbar = NavigationToolbar2TkAgg(canvas, self)
+        toolbar = NavigationToolbar2Tk(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     
@@ -422,7 +422,7 @@ class OverallFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -652,7 +652,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -80,6 +80,18 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.button_overall.grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan = 2, sticky="nswe")
         rowN+=1
         
+        self.button_per_bunch = tk.Button(
+            self.frame2,text='Overall plots per bunch',
+            command = self.perBunchPlot)
+        self.button_per_bunch.grid(
+            row=rowN,
+            column=0,
+            pady=5,
+            padx=5,
+            columnspan=2,
+            sticky="nswe")
+        rowN+=1
+
         self.button_emitGrowth      = tk.Button(self.frame2,text='EmitGrowth',
                                                 command = self.emitGrowthPlot)
         self.button_emitGrowth      .grid(row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -163,11 +175,20 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         print(self.__class__.__name__)
 
         plotWindow = tk.Toplevel(self)
-        plotWindow.title('Plot')
+        plotWindow.title('Overall plot')
         
         l=OverallFrame(plotWindow)
         l.pack()    
         
+    def perBunchPlot(self):
+        print(self.__class__.__name__)
+
+        plotWindow = tk.Toplevel(self)
+        plotWindow.title('Bunch plot')
+
+        l=OverallFrame(plotWindow, plot_all_bunches=False)
+        l.pack()
+
     def energyPlot(self,y,ylabel):
         print(sys._getframe().f_back.f_code.co_name)
 
@@ -408,7 +429,7 @@ class PlotFrame(tk.Frame):
         self.destroy()
                 
 class OverallFrame(tk.Frame):
-    def __init__(self, parent):
+    def __init__(self, parent, plot_all_bunches=True):
         tk.Frame.__init__(self, parent)
 
         self.fig = Figure(figsize=(12,5), dpi=100)
@@ -426,6 +447,13 @@ class OverallFrame(tk.Frame):
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
+        if plot_all_bunches:
+            self.set_default_filelist()
+        else:
+            self.bunch = self.choose_bunch()
+            self.set_bunch_filelist(self.bunch)
+            parent.title(f'Bunch {self.bunch} plots')
+
         self.plot()
     def plot(self):
         picNum = 4
@@ -438,28 +466,28 @@ class OverallFrame(tk.Frame):
         
         xl  = 2
         saveName.append('sizeX')
-        fileList[0]     = ['fort.24','fort.27']
+        fileList[0]     = self.fileList[0]
         labelList[0]    = ['rms.X','max.X']
         xdataList[0]    = [xl,xl]
         ydataList[0]    = [4,3]
         xyLabelList[0]  = ['z drection (m)','beam size in X (mm)']
         
         saveName.append('sizeY')
-        fileList[1]     = ['fort.25','fort.27']
+        fileList[1]     = self.fileList[1]
         labelList[1]    = ['rms.Y','max.Y']
         xdataList[1]    = [xl,xl]
         ydataList[1]    = [4,5]
         xyLabelList[1]  = ['z drection (m)','beam size in Y (mm)']
         
         saveName.append('sizeZ')
-        fileList[2]     = ['fort.26','fort.27']
+        fileList[2]     = self.fileList[2]
         labelList[2]    = ['rms.Z','max.Z']
         xdataList[2]    = [xl,xl]
         ydataList[2]    = [3,7]
         xyLabelList[2]  = ['z drection (m)','beam size in Z (mm)']
         
         saveName.append('emitXY')
-        fileList[3]     = ['fort.24','fort.25']
+        fileList[3]     = self.fileList[3]
         labelList[3]    = ['emit.nor.X','emit.nor.Y']
         xdataList[3]    = [xl,xl]
         ydataList[3]    = [8,8]
@@ -504,6 +532,23 @@ class OverallFrame(tk.Frame):
                 
             self.subfig[i].legend(loc='upper center', bbox_to_anchor=(0.5, 1.21),fancybox=True, shadow=True, ncol=5)
         self.canvas.draw()
+    def choose_bunch(self):
+        return tk.simpledialog.askinteger(
+            title='Overall plot',
+            prompt='Choose a bunch number to plot:')
+    def set_bunch_filelist(self, bunch):
+        self.fileList = [[]*2]*4
+        self.fileList[0] = [f'fort.{bunch*1000+24}', f'fort.{bunch*1000+27}']
+        self.fileList[1] = [f'fort.{bunch*1000+25}', f'fort.{bunch*1000+27}']
+        self.fileList[2] = [f'fort.{bunch*1000+26}', f'fort.{bunch*1000+27}']
+        self.fileList[3] = [f'fort.{bunch*1000+24}', f'fort.{bunch*1000+25}']
+    def set_default_filelist(self):
+        self.fileList = [[]*2]*4
+        self.fileList[0] = ['fort.24','fort.27']
+        self.fileList[1] = ['fort.25','fort.27']
+        self.fileList[2] = ['fort.26','fort.27']
+        self.fileList[3] = ['fort.24','fort.25']
+        pass
         
 class EmitGrowthFrame(PlotBaseFrame):
     def __init__(self, parent):

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -341,7 +341,7 @@ class PlotBaseFrame(tk.Frame):
         self.subfig = self.fig.add_subplot(111)
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -397,7 +397,7 @@ class PlotFrame(tk.Frame):
         subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self)
-        canvas.show()
+        canvas.draw()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2Tk(canvas, self)
@@ -419,7 +419,7 @@ class OverallFrame(tk.Frame):
         self.subfig.append(self.fig.add_subplot(224))
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -649,7 +649,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -704,43 +704,49 @@ class EmitGrowthFrame(PlotBaseFrame):
 class TemperatureFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.2, box.y0, box.width, box.height])
         self.plot()
     def plot(self):
-        arg=['ct','fort.24','fort.25','fort.26']
+        filelist = self.get_filelist()
+        xcol, xlabel = self.get_xaxis_parameters()
         labelList= ['X','Y','Z']
         lineType = ['-','--',':']
         col      = ['b','g','r']
         linew    = [2,2,3]
-        picNum = len(arg) - 1
+        picNum = len(filelist)
         plotPath = './post'
         if os.path.exists(plotPath) == False:
             os.makedirs(plotPath)
-            
         self.subfig.cla()
-        for i in range(1,picNum+1):
+        for i in range(0, picNum):
             try:
-                fin = open(arg[i],'r')
+                fin = open(filelist[i],'r')
             except:
-                print( "  ERRPR! Can't open file '" + arg[i] + "'")
+                print( "  ERROR! Can't open file '" + filelist[i] + "'")
                 return
-    
             linesList  = fin.readlines()
-            fin .close()
+            fin.close()
             linesList  = [line.split() for line in linesList ]
-            x   = [float(xrt[0]) for xrt in linesList]
-            yl=5
-            if i==3:
-                yl=4
-            y   = [float(xrt[yl])*float(xrt[yl]) for xrt in linesList]
-            self.subfig.plot(x, y, color = col[(i-1)],linestyle=lineType[i-1], linewidth=linew[i-1],label=labelList[i-1])
-        
-        box = self.subfig.get_position()
-        self.subfig.set_position([box.x0*1.2, box.y0, box.width, box.height])    
-        self.subfig.set_xlabel('T (s)')
+            x = [float(xrt[xcol]) for xrt in linesList]
+            if i==2:
+                ycol = 4
+            else:
+                ycol = 5
+            y = [float(xrt[ycol])*float(xrt[ycol]) for xrt in linesList]
+            self.subfig.plot(x, y, 
+                             color=col[i],
+                             linestyle=lineType[i],
+                             linewidth=linew[i],
+                             label=labelList[i])
+        self.subfig.set_xlabel(xlabel)
         self.subfig.set_ylabel('Temperature')
         self.subfig.legend()
-        
         self.canvas.draw()
+    def get_default_filelist(self):
+        return ['fort.24', 'fort.25', 'fort.26']
+    def get_xaxis_parameters(self):
+        return PlotBaseFrame.get_xaxis_parameters(self, tcol=0, zcol=1)
 
 class PlotHighOrderBaseFrame(tk.Frame):
     ParticleDirec = {'X (mm)'    :2,

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -13,7 +13,7 @@ from tkinter import ttk,filedialog
 import time,os,sys
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
 from matplotlib.figure import Figure
-from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
+from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 from scipy.stats import gaussian_kde
 import numpy as np
 
@@ -35,18 +35,18 @@ IMPACT_T_sciMinLimit  = 0.0001*2
 
 class AdvancedPlotControlFrame(tk.Toplevel):
     """Output"""
-    
+
     def __init__(self, master=None, cnf={}, **kw):
         tk.Toplevel.__init__(self, master, cnf, **kw)
         self.title('ImpactT Plot')
-        self.focus_set()  
+        self.focus_set()
         """Plot Control"""
         self.frame_plotButton = tk.Frame(self)
         self.frame_plotButton.grid(column=0, row = 0, pady=5 ,padx=10, sticky="we")
-        
+
         self.frame_radio = tk.Frame(self.frame_plotButton)
         self.frame_radio.pack(side='top')
-        
+
         self.plotDirct = tk.IntVar()
         self.plotDirct.set(0)
         self.frame_radio.x = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
@@ -58,7 +58,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.frame_radio.z = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
                                            text="Z", value=2)
         self.frame_radio.z.pack(side='left')
-        
+
         self.plotTypeComx = tk.StringVar(self.frame_plotButton,'Rms size (mm)')
         self.plotType = ttk.Combobox(self.frame_plotButton,text=self.plotTypeComx,
                                      width = 20,
@@ -66,20 +66,20 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.plotType.pack(side = 'top')
         self.plot = tk.Button(self.frame_plotButton,text='plot',command=self.makePlot)
         self.plot.pack(fill = 'both',expand =1,side = 'top',padx=10)
-        
+
         self.t = ttk.Separator(self, orient=tk.HORIZONTAL).grid(column=0, row = 1, sticky="we")
 
-           
+
         self.frame2 = tk.Frame(self, height =_height/5, width = _width)
         self.frame2.grid(column=0, row = 2, pady=5 ,padx=10, sticky="nswe")
-        
+
         rowN=0
-        
+
         self.button_overall = tk.Button(self.frame2,text='Overall',
                                command = self.overallPlot)
         self.button_overall.grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan = 2, sticky="nswe")
         rowN+=1
-        
+
         self.button_emitGrowth      = tk.Button(self.frame2,text='EmitGrowth',
                                                 command = self.emitGrowthPlot)
         self.button_emitGrowth      .grid(row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -103,7 +103,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                 command = lambda: self.energyPlot(6,'Rms delta E (MC^2)'))
         self.button_dw              .grid(row = rowN, column=1, pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
+
         self.button_Temperature         = tk.Button(self.frame2,text='Temperature Plot',
                                                     command = self.makeTemperaturePlot)
         self.button_Temperature         .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -111,15 +111,15 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.liveParticlePlot)
         self.button_Loss                .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
-        
+
         self.max                        = tk.Button(self.frame2,text='Max amplitude',
                                                     command = self.maxPlot)
         self.max                        .grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan=2,sticky="nswe")
         rowN+=1
-        
+
         self.button_3order              = tk.Button(self.frame2,text='3 order parameter',
                                                     command = self.make3orderPlot)
         self.button_3order              .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -127,11 +127,11 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.make4orderPlot)
         self.button_4order              .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
 
-        
+
         self.button_Particle            = tk.Button(self.frame2,text='Phase Space Plot',
                                                     command = self.ParticlePlot)
         self.button_Particle            .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -139,7 +139,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.ParticleDensityPlot1D)
         self.button_ParticleDesity1D    .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
+
         self.button_ParticleDensity     = tk.Button(self.frame2,text='Density2D (by Grid)',
                                                     command = self.ParticleDensityPlot)
         self.button_ParticleDensity     .grid( row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -147,10 +147,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.ParticleDensityPlot2)
         self.button_ParticleDensity2    .grid(row = rowN, column=1, pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
-        
+
         self.button_SlicePlot     = tk.Button(self.frame2,text='Slice plot',
                                                     command = self.SlicePlot)
         self.button_SlicePlot     .grid( row = rowN, column=0, columnspan=2, pady=5 ,padx=5, sticky="nswe")
@@ -164,46 +164,46 @@ class AdvancedPlotControlFrame(tk.Toplevel):
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=OverallFrame(plotWindow)
-        l.pack()    
-        
+        l.pack()
+
     def energyPlot(self,y,ylabel):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title(sys._getframe().f_back.f_code.co_name)
-        
+
         l=PlotFrame(plotWindow,'fort.18',1,y,ylabel)
         l.pack()
-    
+
     def emitGrowthPlot(self):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=EmitGrowthFrame(plotWindow)
-        l.pack()   
-        
+        l.pack()
+
     def makeTemperaturePlot(self):
         print((self.plotType))
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=TemperatureFrame(plotWindow)
         l.pack()
-        
+
     def liveParticlePlot(self):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title(sys._getframe().f_back.f_code.co_name)
-        
+
         l=PlotFrame(plotWindow,'fort.28',1,4,'Live particle number')
         l.pack()
-        
+
     def ParticlePlot(self):
         print(self.__class__.__name__)
         filename = filedialog.askopenfilename(parent=self)
@@ -212,13 +212,13 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Phase Space Plot')
-        
+
         l=ParticlePlot.ParticleFrame(plotWindow,filename,1.0,'ImpactT')
-        l.pack() 
-                
+        l.pack()
+
     def ParticleDensityPlot(self):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -229,10 +229,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame_weight2D(plotWindow,fileName,1.0,'ImpactT')
         l.pack()
-        
+
     def ParticleDensityPlot1D(self):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -243,10 +243,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame_weight1D(plotWindow,fileName,1.0,'ImpactT')
         l.pack()
-                    
+
     def ParticleDensityPlot2(self):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -257,10 +257,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame2D_slow(plotWindow,fileName,1.0,'ImpactT')
         l.pack()
-        
+
     def SlicePlot(self):
         fileName=filedialog.askopenfilename(parent=self)
         try:
@@ -268,26 +268,26 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Slice Plot')
-        
+
         l=SlicePlot.SliceBaseFrame(plotWindow,fileName)
         l.pack()
-        
+
     def makePlot(self):
         print(self.__class__.__name__)
-        
-        PlotFileName='fort.'+str(self.plotDirct.get()+24)        
+
+        PlotFileName='fort.'+str(self.plotDirct.get()+24)
         yx=IMPACT_T_ADVANCED_PLOT_TYPE[self.plotType.get()]
         yl=yx if self.plotDirct.get()!=2 else yx-1
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=PlotFrame(plotWindow,PlotFileName,1,yl,self.plotType.get())
         l.pack()
-        
+
 
     def maxPlot(self):
         print(self.__class__.__name__)
@@ -297,12 +297,12 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('maxPlot')
-        
+
         l=PlotMaxFrame(plotWindow,filename)
-        l.pack() 
+        l.pack()
     def make3orderPlot(self):
         print(self.__class__.__name__)
         filename = 'fort.29'
@@ -311,13 +311,13 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('make3orderPlot')
-        
+
         l=Plot3orderFrame(plotWindow,filename)
-        l.pack() 
-        
+        l.pack()
+
     def make4orderPlot(self):
         print(self.__class__.__name__)
         filename = 'fort.30'
@@ -326,12 +326,12 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('make4orderPlot')
-        
+
         l=Plot4orderFrame(plotWindow,filename)
-        l.pack() 
+        l.pack()
 
 class PlotBaseFrame(tk.Frame):
     def __init__(self, parent):
@@ -343,13 +343,13 @@ class PlotBaseFrame(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-    
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
 
-        
+
+
 class PlotFrame(tk.Frame):
     def __init__(self, parent,PlotFileName,xl,yl,labelY):
         tk.Frame.__init__(self, parent)
@@ -364,18 +364,18 @@ class PlotFrame(tk.Frame):
         except:
             print(( "  ERRPR! Can't open file '" + PlotFileName + "'"))
             return
-        
+
         linesList  = fin.readlines()
         fin .close()
         linesList  = [line.split() for line in linesList ]
         x   = np.array([float(xrt[xl]) for xrt in linesList])
         y   = np.array([float(xrt[yl]) for xrt in linesList])
-        
+
         if labelY in ['Centriod location (mm)','Rms size (mm)','Rmax (mm)']:
             y = y*1.0e3       # unit convert from m to mm
         elif labelY in ['Emittance (mm-mrad)']:
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
-        
+
         fig = Figure(figsize=(7,5), dpi=100)
         subfig = fig.add_subplot(111)
         subfig.plot(x,y)
@@ -390,12 +390,12 @@ class PlotFrame(tk.Frame):
             self.subfig.xaxis.set_major_formatter(IMPACT_T_SciFormatter)
         if (yMax-yMin)>IMPACT_T_sciMaxLimit or (yMax-yMin)<IMPACT_T_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_T_SciFormatter)
-        
+
         #xmajorFormatter = FormatStrFormatter('%2.2E')
         #subfig.yaxis.set_major_formatter(xmajorFormatter)
         box = subfig.get_position()
         subfig.set_position([box.x0*1.45, box.y0*1.1, box.width, box.height])
-        
+
         canvas = FigureCanvasTkAgg(fig, self)
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
@@ -403,10 +403,10 @@ class PlotFrame(tk.Frame):
         toolbar = NavigationToolbar2TkAgg(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-    
+
     def quit(self):
         self.destroy()
-                
+
 class OverallFrame(tk.Frame):
     def __init__(self, parent):
         tk.Frame.__init__(self, parent)
@@ -421,11 +421,11 @@ class OverallFrame(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-    
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
     def plot(self):
         picNum = 4
@@ -435,7 +435,7 @@ class OverallFrame(tk.Frame):
         xdataList   = [[]*2]*picNum
         ydataList   = [[]*2]*picNum
         xyLabelList = [[]*2]*picNum
-        
+
         xl  = 2
         saveName.append('sizeX')
         fileList[0]     = ['fort.24','fort.27']
@@ -443,28 +443,28 @@ class OverallFrame(tk.Frame):
         xdataList[0]    = [xl,xl]
         ydataList[0]    = [4,3]
         xyLabelList[0]  = ['z drection (m)','beam size in X (mm)']
-        
+
         saveName.append('sizeY')
         fileList[1]     = ['fort.25','fort.27']
         labelList[1]    = ['rms.Y','max.Y']
         xdataList[1]    = [xl,xl]
         ydataList[1]    = [4,5]
         xyLabelList[1]  = ['z drection (m)','beam size in Y (mm)']
-        
+
         saveName.append('sizeZ')
         fileList[2]     = ['fort.26','fort.27']
         labelList[2]    = ['rms.Z','max.Z']
         xdataList[2]    = [xl,xl]
         ydataList[2]    = [3,7]
         xyLabelList[2]  = ['z drection (m)','beam size in Z (mm)']
-        
+
         saveName.append('emitXY')
         fileList[3]     = ['fort.24','fort.25']
         labelList[3]    = ['emit.nor.X','emit.nor.Y']
         xdataList[3]    = [xl,xl]
         ydataList[3]    = [8,8]
         xyLabelList[3]  = ['z drection (m)','emittance at X and Y (mm*mrad)']
-        
+
         lineType = ['r-','b--']
 
         for i in range(0,picNum):
@@ -486,13 +486,13 @@ class OverallFrame(tk.Frame):
                 elif i == picNum-1:
                     y=y*1.0e6
                 self.subfig[i].plot(x, y, lineType[j], linewidth=2, label=labelList[i][j])
-                
-                
+
+
             self.subfig[i].set_xlabel(xyLabelList[i][0])
             self.subfig[i].set_ylabel(xyLabelList[i][1])
             box = self.subfig[i].get_position()
             self.subfig[i].set_position([box.x0*1.1, box.y0*1.1, box.width, box.height *0.88])
-            
+
             xMax = np.max(x)
             xMin = np.min(x)
             yMax = np.max(y)
@@ -501,22 +501,22 @@ class OverallFrame(tk.Frame):
                 self.subfig[i].xaxis.set_major_formatter(IMPACT_T_SciFormatter)
             if (yMax-yMin)>IMPACT_T_sciMaxLimit or (yMax-yMin)<IMPACT_T_sciMinLimit:
                 self.subfig[i].yaxis.set_major_formatter(IMPACT_T_SciFormatter)
-                
+
             self.subfig[i].legend(loc='upper center', bbox_to_anchor=(0.5, 1.21),fancybox=True, shadow=True, ncol=5)
         self.canvas.draw()
-        
+
 class EmitGrowthFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
         self.plot()
-    def plot(self):        
+    def plot(self):
         fileList        = ['fort.24','fort.25']
         xdataList       = [2,2]
         ydataList       = [8,8]
         xyLabelList     = ['Z (m)','Avg emit growth in X and Y']
-        
+
         lineType = ['r-','b--']
-        
+
         try:
             fin1 = open(fileList[0],'r')
         except:
@@ -543,7 +543,7 @@ class EmitGrowthFrame(PlotBaseFrame):
             y   = [(float(linesList1[k][yId]) + float(linesList2[k][yId]))/2 / start -1 for k in range(len(linesList1))]
         except:
             print("  ERRPR! Can't read data '" + fileList[1] + "'")
-        
+
         self.subfig.cla()
         self.subfig.plot(x, y, lineType[0], linewidth=2, label='emit.growth')
         box = self.subfig.get_position()
@@ -551,9 +551,9 @@ class EmitGrowthFrame(PlotBaseFrame):
         self.subfig.set_xlabel(xyLabelList[0])
         self.subfig.set_ylabel(xyLabelList[1])
         self.subfig.legend()
-        
+
         self.canvas.draw()
-        
+
 class TemperatureFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
@@ -568,7 +568,7 @@ class TemperatureFrame(PlotBaseFrame):
         plotPath = './post'
         if os.path.exists(plotPath) == False:
             os.makedirs(plotPath)
-            
+
         self.subfig.cla()
         for i in range(1,picNum+1):
             try:
@@ -576,7 +576,7 @@ class TemperatureFrame(PlotBaseFrame):
             except:
                 print( "  ERRPR! Can't open file '" + arg[i] + "'")
                 return
-    
+
             linesList  = fin.readlines()
             fin .close()
             linesList  = [line.split() for line in linesList ]
@@ -586,13 +586,13 @@ class TemperatureFrame(PlotBaseFrame):
                 yl=4
             y   = [float(xrt[yl])*float(xrt[yl]) for xrt in linesList]
             self.subfig.plot(x, y, color = col[(i-1)],linestyle=lineType[i-1], linewidth=linew[i-1],label=labelList[i-1])
-        
+
         box = self.subfig.get_position()
-        self.subfig.set_position([box.x0*1.2, box.y0, box.width, box.height])    
+        self.subfig.set_position([box.x0*1.2, box.y0, box.width, box.height])
         self.subfig.set_xlabel('T (s)')
         self.subfig.set_ylabel('Temperature')
         self.subfig.legend()
-        
+
         self.canvas.draw()
 
 class PlotHighOrderBaseFrame(tk.Frame):
@@ -610,14 +610,14 @@ class PlotHighOrderBaseFrame(tk.Frame):
         except:
             print(( "  ERROR! Can't open file '" + PlotFileName + "'"))
             return
-        
+
         self.data = np.transpose(self.data)
         for i in range(0,6,2):
             self.data[i] = self.data[i] * 1e3  # from m to mm
-        
+
         self.frame_PlotParticleControl = tk.Frame(self)
         self.frame_PlotParticleControl.pack()
-        
+
         self.label_x    = tk.Label(self.frame_PlotParticleControl, text="Direction:")
         self.label_x.pack(side='left')
 
@@ -626,7 +626,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
                                        width=6,
                                        values=['X (mm)', 'Px (MC)', 'Y (mm)', 'Py (MC)','Z (mm)','Pz (MC)'])
         self.ppc1.pack(fill = 'both',expand =1,side = 'left')
-        
+
         LARGE_FONT= ("Verdana", 12)
         self.button_ppc=tk.Button(self.frame_PlotParticleControl)
         self.button_ppc["text"]         = "Plot"
@@ -638,11 +638,11 @@ class PlotHighOrderBaseFrame(tk.Frame):
 
         x   = 1
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.fig = Figure(figsize=(7,5), dpi=100)
         self.subfig = self.fig.add_subplot(111)
         self.subfig.scatter(self.data[x],self.data[y],s=1)
-        
+
         xmajorFormatter = FormatStrFormatter('%2.2E')
         self.subfig.yaxis.set_major_formatter(xmajorFormatter)
         box = self.subfig.get_position()
@@ -655,19 +655,19 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
-        
+
 class PlotMaxFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[1],self.data[y])
-        
+
         axis_format_T(self.data[1],self.data[y], self.subfig)
 
         self.subfig.set_xlabel('Z (m)')
@@ -676,17 +676,17 @@ class PlotMaxFrame(PlotHighOrderBaseFrame):
         else:
             self.subfig.set_ylabel('Max '+ self.ppc1.get())
         self.canvas.draw()
-        
+
 class Plot3orderFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[1],self.data[y])
-        
+
         xmajorFormatter = FormatStrFormatter('%2.2E')
         self.subfig.yaxis.set_major_formatter(xmajorFormatter)
 
@@ -696,17 +696,17 @@ class Plot3orderFrame(PlotHighOrderBaseFrame):
         else:
             self.subfig.set_ylabel('cubic root of 3rd'+ self.ppc1.get())
         self.canvas.draw()
-        
+
 class Plot4orderFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[1],self.data[y])
-        
+
         #xmajorFormatter = FormatStrFormatter('%2.2E')
         #self.subfig.yaxis.set_major_formatter(xmajorFormatter)
 
@@ -716,7 +716,7 @@ class Plot4orderFrame(PlotHighOrderBaseFrame):
         else:
             self.subfig.set_ylabel('square square root of 4th '+ self.ppc1.get())
         self.canvas.draw()
-        
+
 def axis_format_T(xData,yData,subfig):
     xMax = np.max(xData)
     xMin = np.min(xData)

--- a/GUI/src/ImpactTPlot.py
+++ b/GUI/src/ImpactTPlot.py
@@ -654,55 +654,25 @@ class OverallFrame(tk.Frame):
 class EmitGrowthFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
-
-        self.Nbunch = int(parent.master.master.Nbunch.get())
-        if self.Nbunch > 1:
-            self.create_option_frame(self.Nbunch)
-
         box = self.subfig.get_position()
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
-
         self.plot()
-    def create_option_frame(self, Nbunch):
-        """Creates a bar at the top to select options of the plot"""
-        self.option_frame = tk.Frame(self)
-        self.option_frame.pack()
-        self.bunch_list = ['All']
-        self.bunch_list.extend(range(1, Nbunch + 1))
-        self.bunch_default = tk.StringVar(self.option_frame, 'All')
-        self.bunch_label = tk.Label(self.option_frame, text="Select bunch: ")
-        self.bunch_label.pack(side='left')
-        self.bunch_select = ttk.Combobox(
-            self.option_frame,
-            text=self.bunch_default,
-            width=6,
-            values=self.bunch_list)
-        self.bunch_select.pack(fill='both', expand=1, side='left')
-        self.plot_button = tk.Button(
-            self.option_frame,
-            text="Plot",
-            foreground="blue",
-            bg="red",
-            font=("Verdana", 12),
-            command=self.plot)
-        self.plot_button.pack(fill='both', expand=1, side='left')
-    def plot(self):        
-        fileList        = self.get_filelist()
-        xdataList       = [2,2]
-        ydataList       = [8,8]
-        xyLabelList     = ['Z (m)','Avg emit growth in X and Y']
-        
+    def plot(self):
+        fileList = self.get_filelist()
+        xcol, xlabel = self.get_xaxis_parameters()
+        xdataList = [xcol, xcol]
+        ydataList = [8, 8]
+        xyLabelList = [xlabel, 'Avg emit growth in X and Y']
         lineType = ['r-','b--']
-        
         try:
             fin1 = open(fileList[0],'r')
         except:
-            print("  ERRPR! Can't open file '" + fileList[0] + "'")
+            print("  ERROR! Can't open file '" + fileList[0] + "'")
             return
         try:
             fin2 = open(fileList[1],'r')
         except:
-            print("  ERRPR! Can't open file '" + fileList[1] + "'")
+            print("  ERROR! Can't open file '" + fileList[1] + "'")
             return
         linesList1  = fin1.readlines()
         linesList2  = fin2.readlines()
@@ -719,33 +689,18 @@ class EmitGrowthFrame(PlotBaseFrame):
                 start=1.0e-16
             y   = [(float(linesList1[k][yId]) + float(linesList2[k][yId]))/2 / start -1 for k in range(len(linesList1))]
         except:
-            print("  ERRPR! Can't read data '" + fileList[1] + "'")
-        
+            print("  ERROR! Can't read data '" + fileList[1] + "'")
         self.subfig.cla()
         self.subfig.plot(x, y, lineType[0], linewidth=2, label='emit.growth')
-        
         self.subfig.set_xlabel(xyLabelList[0])
         self.subfig.set_ylabel(xyLabelList[1])
         self.subfig.legend()
-        
         self.canvas.draw()
-        
     def get_default_filelist(self):
         return ['fort.24', 'fort.25']
-    def get_bunch_filelist(self, bunch):
-        return [f'fort.{bunch*1000+24}', f'fort.{bunch*1000+25}']
-    def get_filelist(self):
-        selected_bunch = self.get_selected_bunch()
-        if selected_bunch == 'All':
-            return self.get_default_filelist()
-        else:
-            return self.get_bunch_filelist(int(selected_bunch))
-    def get_selected_bunch(self):
-        if hasattr(self, "bunch_select"):
-            return self.bunch_select.get()
-        else:
-            return 'All'
-        
+    def get_xaxis_parameters(self):
+        return PlotBaseFrame.get_xaxis_parameters(self, tcol=1, zcol=2)
+
 class TemperatureFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)

--- a/GUI/src/ImpactTSet.py
+++ b/GUI/src/ImpactTSet.py
@@ -7,66 +7,66 @@ import os,sys
 
 _height=200
 _width =200
-class AdvancedSetFrame(tk.Toplevel):            
+class AdvancedSetFrame(tk.Toplevel):
     def __init__(self, master, kernel, cnf={}, **kw):
         tk.Toplevel.__init__(self, master, cnf, **kw)
         self.title('Set')
-        self.focus_set()  
+        self.focus_set()
         #self.grab_set()
         rowtemp=0
         self.frame1 = tk.LabelFrame(self, height =_height/10, width = _width,
                                           text="Configuration")
         self.frame1.pack(side = 'top')
-        
+
         """Exe path"""
         self.frame_exe = tk.LabelFrame(self.frame1)
         self.frame_exe.grid(row=rowtemp,column=0,rowspan=2,columnspan=2,sticky='w')
         rowtemp+=2
-        
+
         self.frame_input1 = tk.Frame(self.frame_exe)
         self.frame_input1.grid(row=0,column=0,columnspan=2,sticky='w')
-        
+
         self.label_exePat    = tk.Label(self.frame_input1, text="mpirun:")
         self.label_exePat.pack(side='left')
         self.entry_exePath = tk.Entry(self.frame_input1, width=45,textvariable=master.MPI_EXE)
         self.entry_exePath.pack(side='left')
-        
+
         self.frame_input = tk.Frame(self.frame_exe,borderwidth=0, highlightthickness=0)
         self.frame_input.grid(row=1,column=0,columnspan=2,sticky='w')
-        
+
         self.label_exePat    = tk.Label(self.frame_input, text="Exe:")
         self.label_exePat.pack(side='left')
         self.entry_exePath = tk.Entry(self.frame_input, width=45,textvariable=master.IMPACT_T_EXE)
         self.entry_exePath.pack(side='left')
-        
+
         self.button_exePath = tk.Button(self.frame_input)
         self.button_exePath["text"]        = "..."
         self.button_exePath["command"]     = lambda: self.changeExe(master.IMPACT_T_EXE)
         self.button_exePath.pack(side = 'left')
-        
+
         self.button_exePath.bind("<Enter>", lambda event, h=self.button_exePath: h.configure(bg="#00CD00"))
         self.button_exePath.bind("<Leave>", lambda event, h=self.button_exePath: h.configure(bg="#FFFFFF"))
-        
-        
+
+
         """Flag restart"""
-        self.check_restart  = tk.Checkbutton(self.frame1, 
-                                             text="Restart at previous check point", 
+        self.check_restart  = tk.Checkbutton(self.frame1,
+                                             text="Restart at previous check point",
                                              variable=master.FlagRestart)
         self.check_restart  .grid(row=rowtemp,column=0,columnspan=2,sticky='w')
         rowtemp+=1
-        
+
         """Flag error"""
         self.check_error    = tk.Checkbutton(self.frame1, text="Misalignmnet and rotation error", variable=master.Flagerr)
         self.check_error    .grid(row=rowtemp,column=0,columnspan=2,sticky='w')
         rowtemp+=1
-        
+
         """Flag image"""
         self.check_image  = tk.Checkbutton(self.frame1, text="Image current", variable=master.Flagimag)
         self.check_image.grid(row=rowtemp,column=0,columnspan=2,sticky='w')
         if kernel!='ImpactT':
             self.check_image     .config(state='disabled')
         rowtemp+=1
-        
+
         """Zimage"""
         self.label_dt5    = tk.Label(self.frame1, text="Z image")
         self.entry_dt5    = tk.Entry(self.frame1,textvariable=master.Zimage)
@@ -75,10 +75,10 @@ class AdvancedSetFrame(tk.Toplevel):
         if kernel!='ImpactT':
             self.entry_dt5     .config(state='disabled')
         rowtemp+=1
-        
+
         self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
         rowtemp+=1
-         
+
         self.label_mass    = tk.Label(self.frame1, text="Mass (eV)")
         self.entry_mass    = tk.Entry(self.frame1,textvariable=master.ptcMass)
         self.label_mass.grid(row=rowtemp,sticky='W')
@@ -96,21 +96,21 @@ class AdvancedSetFrame(tk.Toplevel):
         self.entry_dt0.grid(row=rowtemp,column=1,sticky='E')
         self.entry_dt0.config(state='disabled')
         rowtemp+=1
-        
+
         """Dimension"""
         self.label_dt1    = tk.Label(self.frame1, text="Dimension")
         self.entry_dt1    = tk.Entry(self.frame1,textvariable=master.Dim)
         self.label_dt1.grid(row=rowtemp,sticky='W')
         self.entry_dt1.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Dimension"""
         self.label_dist    = tk.Label(self.frame1, text="Distribution")
         self.entry_dist    = tk.Entry(self.frame1,textvariable=master.distTypeNumb)
         self.label_dist.grid(row=rowtemp,sticky='W')
         self.entry_dist.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         '''Type of integrator
         self.label_integrator       = tk.Label(self.frame1, text="Integrator")
         self.box_integrator         = ttk.Combobox(self.frame1,textvariable=master.Flagmap,
@@ -120,7 +120,7 @@ class AdvancedSetFrame(tk.Toplevel):
         if kernel=='ImpactT':
             self.box_integrator     .config(state='disabled')
         rowtemp+=1
-        
+
         '''
         """Flag diagnostics"""
         self.label_diag     = tk.Label(self.frame1, text="Output")
@@ -129,12 +129,12 @@ class AdvancedSetFrame(tk.Toplevel):
                                            values=['At given time', 'At bunch centroid', 'No output'])
         self.box_diag       .grid(row=rowtemp, column=1, sticky='E')
         rowtemp+=1
-        
 
-        
+
+
         self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
         rowtemp+=1
-        
+
         """Open boundary condition
         self.label_bc       = tk.Label(self.frame1, text='Boundary')
         self.label_bc       .grid(row=rowtemp,sticky='W')
@@ -146,7 +146,7 @@ class AdvancedSetFrame(tk.Toplevel):
         rowtemp+=1
         """
 
-        
+
         """Computational domain"""
         self.label_domain   = tk.Label(self.frame1, text='Computational Domain:')
         self.label_domain   .grid(row=rowtemp,column=0,columnspan=2,sticky='w')
@@ -168,27 +168,27 @@ class AdvancedSetFrame(tk.Toplevel):
         rowtemp+=1
         self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
         rowtemp+=1
-        
 
-        
+
+
         self.label_Nemission = tk.Label(self.frame1, text='Emission Step')
         self.entry_Nemission = tk.Entry(self.frame1,textvariable=master.Nemission)
         self.label_Nemission .grid(row=rowtemp,sticky='E')
         self.entry_Nemission .grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         self.label_Temission = tk.Label(self.frame1, text='Emission Time')
         self.entry_Temission = tk.Entry(self.frame1,textvariable=master.Temission)
         self.label_Temission .grid(row=rowtemp,sticky='E')
         self.entry_Temission .grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         self.label_Tinitial = tk.Label(self.frame1, text='Initial reference time')
         self.entry_Tinitial = tk.Entry(self.frame1,textvariable=master.Tinitial)
         self.label_Tinitial .grid(row=rowtemp,sticky='E')
         self.entry_Tinitial .grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Advanced distribution"""
         self.frame_Twiss = tk.LabelFrame(self, height =_height/10, width = _width,
                                           text="Initial Distribution")
@@ -198,38 +198,37 @@ class AdvancedSetFrame(tk.Toplevel):
         self.twiss_s = []
         self.twiss_chara = ["sigma(m)","sigmaP","muxpx",'xScale','PxSacle','x shift','px shift']
         for column in range(7):
-            label = tk.Label(self.frame_Twiss, text=self.twiss_chara[column], 
+            label = tk.Label(self.frame_Twiss, text=self.twiss_chara[column],
                             borderwidth=0,
                             width=twisswidth)
             label.grid(row=0, column=column+1, sticky="ns", padx=1, pady=1)
             self.twiss_s.append(label)
-        
+
         self.twiss_x = []
         self.twiss_xchara = ["X","Y","Z"]
         for row in range(3):
-            label = tk.Label(self.frame_Twiss, text=self.twiss_xchara[row], 
+            label = tk.Label(self.frame_Twiss, text=self.twiss_xchara[row],
                                  borderwidth=0, width=2)
             label.grid(row=row+1, column=0, sticky="ns", padx=1, pady=1)
             self.twiss_x.append(label)
-        
+
         self._twiss = []
         for row in range(3):
             current_row = []
             for column in range(7):
-                label = tk.Entry(self.frame_Twiss, 
-                                 textvariable=master.string_sigma[row][column], 
+                label = tk.Entry(self.frame_Twiss,
+                                 textvariable=master.string_sigma[row][column],
                                  borderwidth=0,
                                  width=twisswidth)
                 label.grid(row=row+1, column=column+1, sticky="ns", padx=2, pady=1)
                 current_row.append(label)
             self._twiss.append(current_row)
-            
+
     def changeExe(self,exePath):
         filename = filedialog.askopenfilename(parent=self)
         if filename=='':
             return
-        
+
         exePath.set(filename)
-        
+
         print(exePath.get())
-        

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import ttk,filedialog
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 
@@ -320,7 +320,7 @@ class PlotBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -374,7 +374,7 @@ class PlotFrame(tk.Frame):
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        toolbar = NavigationToolbar2TkAgg(canvas, self)
+        toolbar = NavigationToolbar2Tk(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     
@@ -396,7 +396,7 @@ class OverallFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -621,7 +621,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -317,7 +317,7 @@ class PlotBaseFrame(tk.Frame):
         self.subfig = self.fig.add_subplot(111)
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -371,7 +371,7 @@ class PlotFrame(tk.Frame):
         subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
-        canvas.show()
+        canvas.draw()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2Tk(canvas, self)
@@ -393,7 +393,7 @@ class OverallFrame(tk.Frame):
         self.subfig.append(self.fig.add_subplot(224))
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -618,7 +618,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -13,7 +13,7 @@ from tkinter import ttk,filedialog
 import time,os,sys
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
 from matplotlib.figure import Figure
-from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
+from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 
 #import scipy.ndimage
 from scipy.stats import gaussian_kde
@@ -36,18 +36,18 @@ IMPACT_Z_sciMinLimit  = 0.0001*2
 
 class AdvancedPlotControlFrame(tk.Toplevel):
     """Output"""
-            
+
     def __init__(self, master=None, cnf={}, **kw):
         tk.Toplevel.__init__(self, master, cnf, **kw)
         self.title('ImpactZ Plot')
-        self.focus_set()  
+        self.focus_set()
         """Plot Control"""
         self.frame_plotButton = tk.Frame(self)
         self.frame_plotButton.grid(column=0, row = 0, pady=5 ,padx=10, sticky="we")
-        
+
         self.frame_radio = tk.Frame(self.frame_plotButton)
         self.frame_radio.pack(side='top')
-        
+
         self.plotDirct = tk.IntVar()
         self.plotDirct.set(0)
         self.frame_radio.x = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
@@ -59,7 +59,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.frame_radio.z = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
                                            text="Z", value=2)
         self.frame_radio.z.pack(side='left')
-        
+
         self.plotTypeComx = tk.StringVar(self.frame_plotButton,'Rms size (mm)')
         self.plotType = ttk.Combobox(self.frame_plotButton,text=self.plotTypeComx,
                                      width = 20,
@@ -67,20 +67,20 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.plotType.pack(side = 'top')
         self.plot = tk.Button(self.frame_plotButton,text='plot',command=self.makePlot)
         self.plot.pack(fill = 'both',expand =1,side = 'top',padx=10)
-        
+
         self.t = ttk.Separator(self, orient=tk.HORIZONTAL).grid(column=0, row = 1, sticky="we")
 
-           
+
         self.frame2 = tk.Frame(self, height =_height/5, width = _width)
         self.frame2.grid(column=0, row = 2, pady=5 ,padx=10, sticky="nswe")
-        
+
         rowN=0
-        
+
         self.button_overall = tk.Button(self.frame2,text='Overall',
                                command = self.overallPlot)
         self.button_overall.grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan = 2, sticky="nswe")
         rowN+=1
-        
+
         self.button_emitGrowth      = tk.Button(self.frame2,text='EmitGrowth',
                                                 command = self.emitGrowthPlot)
         self.button_emitGrowth      .grid(row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -104,7 +104,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                 command = lambda: self.energyPlot(1,'Absolute phase (rad)'))
         self.button_dw              .grid(row = rowN, column=1, pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
+
         self.button_Temperature         = tk.Button(self.frame2,text='Temperature Plot',
                                                     command = self.makeTemperaturePlot)
         self.button_Temperature         .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -112,15 +112,15 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.liveParticlePlot)
         self.button_Loss                .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
-        
+
         self.max                        = tk.Button(self.frame2,text='Max amplitude',
                                                     command = self.maxPlot)
         self.max                        .grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan=2,sticky="nswe")
         rowN+=1
-        
+
         self.button_3order              = tk.Button(self.frame2,text='3 order parameter',
                                                     command = self.make3orderPlot)
         self.button_3order              .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -128,8 +128,8 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.make4orderPlot)
         self.button_4order              .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
 
         scaling = float(master.entry_frq.get())*2*3.1415926/299792458
@@ -140,7 +140,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = lambda:self.ParticleDensityPlot1D(scaling))
         self.button_ParticleDesity1D    .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
+
         self.button_ParticleDensity     = tk.Button(self.frame2,text='Density2D (by Grid)',
                                                     command = lambda:self.ParticleDensityPlot(scaling))
         self.button_ParticleDensity     .grid( row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -154,46 +154,46 @@ class AdvancedPlotControlFrame(tk.Toplevel):
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=OverallFrame(plotWindow)
-        l.pack()    
-        
+        l.pack()
+
     def energyPlot(self,y,yLabel):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title(sys._getframe().f_back.f_code.co_name)
-        
+
         l=PlotFrame(plotWindow,'fort.18',0,y,yLabel)
         l.pack()
-    
+
     def emitGrowthPlot(self):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=EmitGrowthFrame(plotWindow)
-        l.pack()   
-        
+        l.pack()
+
     def makeTemperaturePlot(self):
         print((self.plotType))
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=TemperatureFrame(plotWindow)
         l.pack()
-        
+
     def liveParticlePlot(self):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title(sys._getframe().f_back.f_code.co_name)
-        
+
         l=PlotFrame(plotWindow,'fort.28',0,3,'Live particle number')
         l.pack()
-        
+
     def ParticlePlot(self,scaling):
         print(self.__class__.__name__)
         filename = filedialog.askopenfilename(parent=self)
@@ -202,13 +202,13 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Phase Space Plot')
-        
+
         l=ParticlePlot.ParticleFrame(plotWindow,filename,scaling,'ImpactZ')
-        l.pack() 
-                
+        l.pack()
+
     def ParticleDensityPlot(self,scaling):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -219,10 +219,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame_weight2D(plotWindow,fileName,scaling,'ImpactZ')
         l.pack()
-        
+
     def ParticleDensityPlot1D(self,scaling):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -233,10 +233,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame_weight1D(plotWindow,fileName,scaling,'ImpactZ')
         l.pack()
-                
+
     def ParticleDensityPlot2(self,scaling):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -247,23 +247,23 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame2D_slow(plotWindow,fileName,scaling,'ImpactZ')
         l.pack()
-        
+
     def makePlot(self):
         print(self.__class__.__name__)
-        
-        PlotFileName='fort.'+str(self.plotDirct.get()+24)        
+
+        PlotFileName='fort.'+str(self.plotDirct.get()+24)
         yx=IMPACT_Z_ADVANCED_PLOT_TYPE[self.plotType.get()]
         yl=yx if self.plotDirct.get()!=2 else yx-1
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=PlotFrame(plotWindow,PlotFileName,0,yl,self.plotType.get())
         l.pack()
-        
+
 
     def maxPlot(self):
         print(self.__class__.__name__)
@@ -273,12 +273,12 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('maxPlot')
-        
+
         l=PlotMaxFrame(plotWindow,filename)
-        l.pack() 
+        l.pack()
     def make3orderPlot(self):
         print(self.__class__.__name__)
         filename = 'fort.29'
@@ -287,13 +287,13 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Cubic root of 3rd moment')
-        
+
         l=PlotHighorderFrame(plotWindow,filename)
-        l.pack() 
-        
+        l.pack()
+
     def make4orderPlot(self):
         print(self.__class__.__name__)
         filename = 'fort.30'
@@ -302,12 +302,12 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Square root, square root of 4th moment')
-        
+
         l=PlotHighorderFrame(plotWindow,filename)
-        l.pack() 
+        l.pack()
 
 class PlotBaseFrame(tk.Frame):
     def __init__(self, parent):
@@ -319,13 +319,13 @@ class PlotBaseFrame(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-    
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
 
-        
+
+
 class PlotFrame(tk.Frame):
     def __init__(self, parent,PlotFileName,xl,yl,labelY):
         tk.Frame.__init__(self, parent)
@@ -339,25 +339,25 @@ class PlotFrame(tk.Frame):
             fin = open(PlotFileName,'r')
         except:
             print(( "  ERRPR! Can't open file '" + PlotFileName + "'"))
-        
+
         linesList  = fin.readlines()
         fin .close()
         linesList  = [line.split() for line in linesList ]
         x   = np.array([float(xrt[xl]) for xrt in linesList])
         y   = np.array([float(xrt[yl]) for xrt in linesList])
-        
+
         if labelY in ['Centriod location (mm)','Rms size (mm)','Rmax (mm)']:
             y = y*1.0e3       # unit convert from m to mm
         elif labelY in ['Emittance (mm-mrad)']:
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
-        
+
         fig = Figure(figsize=(7,5), dpi=100)
         subfig = fig.add_subplot(111)
         subfig.plot(x,y)
         subfig.set_xlabel('Z (m)')
         subfig.set_ylabel(labelY)
-        
-        
+
+
         xMax = np.max(x)
         xMin = np.min(x)
         yMax = np.max(y)
@@ -366,21 +366,21 @@ class PlotFrame(tk.Frame):
             self.subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
         if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
-        
+
         box = subfig.get_position()
         subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
-        
-        canvas = FigureCanvasTkAgg(fig, self) 
+
+        canvas = FigureCanvasTkAgg(fig, self)
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2TkAgg(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-    
+
     def quit(self):
         self.destroy()
-                
+
 class OverallFrame(tk.Frame):
     def __init__(self, parent):
         tk.Frame.__init__(self, parent)
@@ -395,11 +395,11 @@ class OverallFrame(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-    
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
     def plot(self):
         picNum = 4
@@ -409,35 +409,35 @@ class OverallFrame(tk.Frame):
         xdataList   = [[]*2]*picNum
         ydataList   = [[]*2]*picNum
         xyLabelList = [[]*2]*picNum
-        
+
         saveName.append('sizeX')
         fileList[0]     = ['fort.24','fort.27']
         labelList[0]    = ['rms.X','max.X']
         xdataList[0]    = [0,0]
         ydataList[0]    = [2,1]
         xyLabelList[0]  = ['z drection (m)','beam size in X (mm)']
-        
+
         saveName.append('sizeY')
         fileList[1]     = ['fort.25','fort.27']
         labelList[1]    = ['rms.Y','max.Y']
         xdataList[1]    = [0,0]
         ydataList[1]    = [2,3]
         xyLabelList[1]  = ['z drection (m)','beam size in Y (mm)']
-        
+
         saveName.append('sizeZ')
         fileList[2]     = ['fort.26','fort.27']
         labelList[2]    = ['rms.Z','max.Z']
         xdataList[2]    = [0,0]
         ydataList[2]    = [2,5]
         xyLabelList[2]  = ['z drection (m)','beam size in Z (degree)']
-        
+
         saveName.append('emitXY')
         fileList[3]     = ['fort.24','fort.25']
         labelList[3]    = ['emit.nor.X','emit.nor.Y']
         xdataList[3]    = [0,0]
         ydataList[3]    = [6,6]
         xyLabelList[3]  = ['z drection (m)','emittance at X and Y (mm*mrad)']
-        
+
         lineType = ['r-','b--']
 
         for i in range(0,picNum):
@@ -464,7 +464,7 @@ class OverallFrame(tk.Frame):
             self.subfig[i].set_ylabel(xyLabelList[i][1])
             box = self.subfig[i].get_position()
             self.subfig[i].set_position([box.x0*1.1, box.y0*1.1, box.width, box.height *0.88])
-            
+
             xMax = np.max(x)
             xMin = np.min(x)
             yMax = np.max(y)
@@ -474,24 +474,24 @@ class OverallFrame(tk.Frame):
             if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
                 self.subfig[i].yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
             #xmajorFormatter = FormatStrFormatter('%2.2E')
-            #self.subfig[i].yaxis.set_major_formatter(xmajorFormatter)  
-            
+            #self.subfig[i].yaxis.set_major_formatter(xmajorFormatter)
+
             self.subfig[i].legend(loc='upper center', bbox_to_anchor=(0.5, 1.21),fancybox=True, shadow=True, ncol=5)
 
         self.canvas.draw()
-        
+
 class EmitGrowthFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
         self.plot()
-    def plot(self):        
+    def plot(self):
         fileList        = ['fort.24','fort.25']
         xdataList       = [1,1]
         ydataList       = [7,7]
         xyLabelList     = ['Z (m)','Trans. avg. emit growth']
-        
+
         lineType = ['r-','b--']
-        
+
         try:
             fin1 = open(fileList[0],'r')
         except:
@@ -518,15 +518,15 @@ class EmitGrowthFrame(PlotBaseFrame):
             y   = [(float(linesList1[k][yId]) + float(linesList2[k][yId]))/2 / start -1 for k in range(len(linesList1))]
         except:
             print("  ERRPR! Can't read data '" + fileList[1] + "'")
-            
+
         self.subfig.cla()
         self.subfig.plot(x, y, lineType[0], linewidth=2, label='emit.growth')
         self.subfig.set_xlabel(xyLabelList[0])
         self.subfig.set_ylabel(xyLabelList[1])
         self.subfig.legend()
-        
+
         self.canvas.draw()
-        
+
 class TemperatureFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
@@ -541,7 +541,7 @@ class TemperatureFrame(PlotBaseFrame):
         plotPath = './post'
         if os.path.exists(plotPath) == False:
             os.makedirs(plotPath)
-            
+
         self.subfig.cla()
         for i in range(1,picNum+1):
             try:
@@ -549,7 +549,7 @@ class TemperatureFrame(PlotBaseFrame):
             except:
                 print( "  ERRPR! Can't open file '" + arg[i] + "'")
                 return
-    
+
             linesList  = fin.readlines()
             fin .close()
             linesList  = [line.split() for line in linesList ]
@@ -557,11 +557,11 @@ class TemperatureFrame(PlotBaseFrame):
             yl=4
             y   = [float(xrt[yl])*float(xrt[yl]) for xrt in linesList]
             self.subfig.plot(x, y, color = col[(i-1)],linestyle=lineType[i-1], linewidth=linew[i-1],label=labelList[i-1])
-            
+
         self.subfig.set_xlabel('T (s)')
         self.subfig.set_ylabel('Temperature')
         self.subfig.legend()
-        
+
         self.canvas.draw()
 
 class PlotHighOrderBaseFrame(tk.Frame):
@@ -579,14 +579,14 @@ class PlotHighOrderBaseFrame(tk.Frame):
         except:
             print(( "  ERROR! Can't open file '" + PlotFileName + "'"))
             return
-        
+
         self.data = np.transpose(self.data)
         for i in range(0,4,2):
             self.data[i] = self.data[i] * 1e3  # from m to mm
-            
+
         self.frame_PlotParticleControl = tk.Frame(self)
         self.frame_PlotParticleControl.pack()
-        
+
         self.label_x    = tk.Label(self.frame_PlotParticleControl, text="Direction:")
         self.label_x.pack(side='left')
 
@@ -595,7 +595,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
                                        width=6,
                                        values=['X (mm)', 'Px (MC)', 'Y (mm)', 'Py (MC)','Z (mm)','Pz (MC)'])
         self.ppc1.pack(fill = 'both',expand =1,side = 'left')
-        
+
         LARGE_FONT= ("Verdana", 12)
         self.button_ppc=tk.Button(self.frame_PlotParticleControl)
         self.button_ppc["text"] = "Plot"
@@ -607,11 +607,11 @@ class PlotHighOrderBaseFrame(tk.Frame):
 
         x   = 0
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.fig = Figure(figsize=(6,5), dpi=100)
         self.subfig = self.fig.add_subplot(111)
         self.subfig.scatter(self.data[x],self.data[y],s=1)
-        
+
         xmajorFormatter = FormatStrFormatter('%2.2E')
         self.subfig.yaxis.set_major_formatter(xmajorFormatter)
         box = self.subfig.get_position()
@@ -624,39 +624,39 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
-        
+
 class PlotMaxFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[0],self.data[y])
-    
+
         axis_format_Z(self.data[0],self.data[y], self.subfig)
-        
+
         self.subfig.set_xlabel('Z (m)')
         if y%2==1:
             self.subfig.set_ylabel('Max '+ self.ppc1.get())
         else:
             self.subfig.set_ylabel('Max '+ self.ppc1.get())
         self.canvas.draw()
-        
-        
+
+
 class PlotHighorderFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[0],self.data[y])
-        
+
         xmajorFormatter = FormatStrFormatter('%2.2E')
         self.subfig.yaxis.set_major_formatter(xmajorFormatter)
 
@@ -670,7 +670,7 @@ class PlotHighorderFrame(PlotHighOrderBaseFrame):
         elif y==6:
             self.subfig.set_ylabel('Energy deviation (MeV)')
         self.canvas.draw()
-        
+
 def axis_format_Z(xData,yData,subfig):
     xMax = np.max(xData)
     xMin = np.min(xData)

--- a/GUI/src/ImpactZPlot.py
+++ b/GUI/src/ImpactZPlot.py
@@ -352,10 +352,10 @@ class PlotFrame(tk.Frame):
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
         
         fig = Figure(figsize=(7,5), dpi=100)
-        subfig = fig.add_subplot(111)
-        subfig.plot(x,y)
-        subfig.set_xlabel('Z (m)')
-        subfig.set_ylabel(labelY)
+        self.subfig = fig.add_subplot(111)
+        self.subfig.plot(x,y)
+        self.subfig.set_xlabel('Z (m)')
+        self.subfig.set_ylabel(labelY)
         
         
         xMax = np.max(x)
@@ -367,8 +367,8 @@ class PlotFrame(tk.Frame):
         if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
         
-        box = subfig.get_position()
-        subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
         canvas.draw()
@@ -677,6 +677,6 @@ def axis_format_Z(xData,yData,subfig):
     yMax = np.max(yData)
     yMin = np.min(yData)
     if (xMax-xMin)>IMPACT_Z_sciMaxLimit or (xMax-xMin)<IMPACT_Z_sciMinLimit:
-        subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
     if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
-        subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -14,7 +14,7 @@ from tkinter import ttk,filedialog
 import time,os,sys
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
 from matplotlib.figure import Figure
-from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
+from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 
 #import scipy.ndimage
 from scipy.stats import gaussian_kde
@@ -37,18 +37,18 @@ IMPACT_Z_sciMinLimit  = 0.0001*2
 
 class AdvancedPlotControlFrame(tk.Toplevel):
     """Output"""
-            
+
     def __init__(self, master=None, cnf={}, **kw):
         tk.Toplevel.__init__(self, master, cnf, **kw)
         self.title('ImpactZ Plot')
-        self.focus_set()  
+        self.focus_set()
         """Plot Control"""
         self.frame_plotButton = tk.Frame(self)
         self.frame_plotButton.grid(column=0, row = 0, pady=5 ,padx=10, sticky="we")
-        
+
         self.frame_radio = tk.Frame(self.frame_plotButton)
         self.frame_radio.pack(side='top')
-        
+
         self.plotDirct = tk.IntVar()
         self.plotDirct.set(0)
         self.frame_radio.x = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
@@ -60,7 +60,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.frame_radio.z = tk.Radiobutton(self.frame_radio, variable=self.plotDirct,
                                            text="Z", value=2)
         self.frame_radio.z.pack(side='left')
-        
+
         self.plotTypeComx = tk.StringVar(self.frame_plotButton,'Rms size (mm)')
         self.plotType = ttk.Combobox(self.frame_plotButton,text=self.plotTypeComx,
                                      width = 20,
@@ -68,20 +68,20 @@ class AdvancedPlotControlFrame(tk.Toplevel):
         self.plotType.pack(side = 'top')
         self.plot = tk.Button(self.frame_plotButton,text='plot',command=self.makePlot)
         self.plot.pack(fill = 'both',expand =1,side = 'top',padx=10)
-        
+
         self.t = ttk.Separator(self, orient=tk.HORIZONTAL).grid(column=0, row = 1, sticky="we")
 
-           
+
         self.frame2 = tk.Frame(self, height =_height/5, width = _width)
         self.frame2.grid(column=0, row = 2, pady=5 ,padx=10, sticky="nswe")
-        
+
         rowN=0
-        
+
         self.button_overall = tk.Button(self.frame2,text='Overall',
                                command = self.overallPlot)
         self.button_overall.grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan = 2, sticky="nswe")
         rowN+=1
-        
+
         self.button_emitGrowth      = tk.Button(self.frame2,text='EmitGrowth',
                                                 command = self.emitGrowthPlot)
         self.button_emitGrowth      .grid(row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -105,7 +105,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                 command = lambda: self.energyPlot(1,'Absolute phase (rad)'))
         self.button_dw              .grid(row = rowN, column=1, pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
+
         self.button_Temperature         = tk.Button(self.frame2,text='Temperature Plot',
                                                     command = self.makeTemperaturePlot)
         self.button_Temperature         .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -113,15 +113,15 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.liveParticlePlot)
         self.button_Loss                .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
-        
+
         self.max                        = tk.Button(self.frame2,text='Max amplitude',
                                                     command = self.maxPlot)
         self.max                        .grid(row = rowN, column=0,  pady=5 ,padx=5, columnspan=2,sticky="nswe")
         rowN+=1
-        
+
         self.button_3order              = tk.Button(self.frame2,text='3 order parameter',
                                                     command = self.make3orderPlot)
         self.button_3order              .grid(row = rowN, column=0,  pady=5 ,padx=5, sticky="nswe")
@@ -129,8 +129,8 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = self.make4orderPlot)
         self.button_4order              .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
-        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")        
+
+        self.t = ttk.Separator(self.frame2, orient=tk.HORIZONTAL).grid(column=0, row = rowN, columnspan=2,sticky="we")
         rowN+=1
 
         scaling = float(master.entry_frq.get())*2*3.1415926/299792458
@@ -141,7 +141,7 @@ class AdvancedPlotControlFrame(tk.Toplevel):
                                                     command = lambda:self.ParticleDensityPlot1D(scaling))
         self.button_ParticleDesity1D    .grid(row = rowN, column=1,  pady=5 ,padx=5, sticky="nswe")
         rowN+=1
-        
+
         self.button_ParticleDensity     = tk.Button(self.frame2,text='Density2D (by Grid)',
                                                     command = lambda:self.ParticleDensityPlot(scaling))
         self.button_ParticleDensity     .grid( row = rowN, column=0, pady=5 ,padx=5, sticky="nswe")
@@ -155,46 +155,46 @@ class AdvancedPlotControlFrame(tk.Toplevel):
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=OverallFrame(plotWindow)
-        l.pack()    
-        
+        l.pack()
+
     def energyPlot(self,y,yLabel):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title(sys._getframe().f_back.f_code.co_name)
-        
+
         l=PlotFrame(plotWindow,'fort.18',0,y,yLabel)
         l.pack()
-    
+
     def emitGrowthPlot(self):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=EmitGrowthFrame(plotWindow)
-        l.pack()   
-        
+        l.pack()
+
     def makeTemperaturePlot(self):
         print((self.plotType))
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=TemperatureFrame(plotWindow)
         l.pack()
-        
+
     def liveParticlePlot(self):
         print(sys._getframe().f_back.f_code.co_name)
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title(sys._getframe().f_back.f_code.co_name)
-        
+
         l=PlotFrame(plotWindow,'fort.28',0,3,'Live particle number')
         l.pack()
-        
+
     def ParticlePlot(self,scaling):
         print(self.__class__.__name__)
         filename = filedialog.askopenfilename(parent=self)
@@ -203,13 +203,13 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Phase Space Plot')
-        
+
         l=ParticlePlot.ParticleFrame(plotWindow,filename,scaling,'ImpactZ')
-        l.pack() 
-                
+        l.pack()
+
     def ParticleDensityPlot(self,scaling):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -220,10 +220,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame_weight2D(plotWindow,fileName,scaling,'ImpactZ')
         l.pack()
-        
+
     def ParticleDensityPlot1D(self,scaling):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -234,10 +234,10 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame_weight1D(plotWindow,fileName,scaling,'ImpactZ')
         l.pack()
-                
+
     def ParticleDensityPlot2(self,scaling):
         print(self.__class__.__name__)
         fileName=filedialog.askopenfilename(parent=self)
@@ -248,23 +248,23 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             return
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=ParticlePlot.ParticleDensityFrame2D_slow(plotWindow,fileName,scaling,'ImpactZ')
         l.pack()
-        
+
     def makePlot(self):
         print(self.__class__.__name__)
-        
-        PlotFileName='fort.'+str(self.plotDirct.get()+24)        
+
+        PlotFileName='fort.'+str(self.plotDirct.get()+24)
         yx=IMPACT_Z_ADVANCED_PLOT_TYPE[self.plotType.get()]
         yl=yx if self.plotDirct.get()!=2 else yx-1
 
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Plot')
-        
+
         l=PlotFrame(plotWindow,PlotFileName,0,yl,self.plotType.get())
         l.pack()
-        
+
 
     def maxPlot(self):
         print(self.__class__.__name__)
@@ -274,12 +274,12 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('maxPlot')
-        
+
         l=PlotMaxFrame(plotWindow,filename)
-        l.pack() 
+        l.pack()
     def make3orderPlot(self):
         print(self.__class__.__name__)
         filename = 'fort.29'
@@ -288,13 +288,13 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Cubic root of 3rd moment')
-        
+
         l=PlotHighorderFrame(plotWindow,filename)
-        l.pack() 
-        
+        l.pack()
+
     def make4orderPlot(self):
         print(self.__class__.__name__)
         filename = 'fort.30'
@@ -303,12 +303,12 @@ class AdvancedPlotControlFrame(tk.Toplevel):
             t.close()
         except:
             return
-        
+
         plotWindow = tk.Toplevel(self)
         plotWindow.title('Square root, square root of 4th moment')
-        
+
         l=PlotHighorderFrame(plotWindow,filename)
-        l.pack() 
+        l.pack()
 
 class PlotBaseFrame(tk.Frame):
     def __init__(self, parent):
@@ -320,13 +320,13 @@ class PlotBaseFrame(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-    
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
 
-        
+
+
 class PlotFrame(tk.Frame):
     def __init__(self, parent,PlotFileName,xl,yl,labelY):
         tk.Frame.__init__(self, parent)
@@ -340,25 +340,25 @@ class PlotFrame(tk.Frame):
             fin = open(PlotFileName,'r')
         except:
             print(( "  ERRPR! Can't open file '" + PlotFileName + "'"))
-        
+
         linesList  = fin.readlines()
         fin .close()
         linesList  = [line.split() for line in linesList ]
         x   = np.array([float(xrt[xl]) for xrt in linesList])
         y   = np.array([float(xrt[yl]) for xrt in linesList])
-        
+
         if labelY in ['Centriod location (mm)','Rms size (mm)','Rmax (mm)']:
             y = y*1.0e3       # unit convert from m to mm
         elif labelY in ['Emittance (mm-mrad)']:
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
-        
+
         fig = Figure(figsize=(7,5), dpi=100)
         subfig = fig.add_subplot(111)
         subfig.plot(x,y)
         subfig.set_xlabel('Z (m)')
         subfig.set_ylabel(labelY)
-        
-        
+
+
         xMax = np.max(x)
         xMin = np.min(x)
         yMax = np.max(y)
@@ -367,21 +367,21 @@ class PlotFrame(tk.Frame):
             self.subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
         if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
-        
+
         box = subfig.get_position()
         subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
-        
-        canvas = FigureCanvasTkAgg(fig, self) 
+
+        canvas = FigureCanvasTkAgg(fig, self)
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2TkAgg(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-    
+
     def quit(self):
         self.destroy()
-                
+
 class OverallFrame(tk.Frame):
     def __init__(self, parent):
         tk.Frame.__init__(self, parent)
@@ -396,11 +396,11 @@ class OverallFrame(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-    
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
     def plot(self):
         picNum = 4
@@ -410,35 +410,35 @@ class OverallFrame(tk.Frame):
         xdataList   = [[]*2]*picNum
         ydataList   = [[]*2]*picNum
         xyLabelList = [[]*2]*picNum
-        
+
         saveName.append('sizeX')
         fileList[0]     = ['fort.24','fort.27']
         labelList[0]    = ['rms.X','max.X']
         xdataList[0]    = [0,0]
         ydataList[0]    = [2,1]
         xyLabelList[0]  = ['z drection (m)','beam size in X (mm)']
-        
+
         saveName.append('sizeY')
         fileList[1]     = ['fort.25','fort.27']
         labelList[1]    = ['rms.Y','max.Y']
         xdataList[1]    = [0,0]
         ydataList[1]    = [2,3]
         xyLabelList[1]  = ['z drection (m)','beam size in Y (mm)']
-        
+
         saveName.append('sizeZ')
         fileList[2]     = ['fort.26','fort.27']
         labelList[2]    = ['rms.Z','max.Z']
         xdataList[2]    = [0,0]
         ydataList[2]    = [2,5]
         xyLabelList[2]  = ['z drection (m)','beam size in Z (mm)']
-        
+
         saveName.append('emitXY')
         fileList[3]     = ['fort.24','fort.25']
         labelList[3]    = ['emit.nor.X','emit.nor.Y']
         xdataList[3]    = [0,0]
         ydataList[3]    = [6,6]
         xyLabelList[3]  = ['z drection (m)','emittance at X and Y (mm*mrad)']
-        
+
         lineType = ['r-','b--']
 
         for i in range(0,picNum):
@@ -465,7 +465,7 @@ class OverallFrame(tk.Frame):
             self.subfig[i].set_ylabel(xyLabelList[i][1])
             box = self.subfig[i].get_position()
             self.subfig[i].set_position([box.x0*1.1, box.y0*1.1, box.width, box.height *0.88])
-            
+
             xMax = np.max(x)
             xMin = np.min(x)
             yMax = np.max(y)
@@ -475,24 +475,24 @@ class OverallFrame(tk.Frame):
             if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
                 self.subfig[i].yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
             #xmajorFormatter = FormatStrFormatter('%2.2E')
-            #self.subfig[i].yaxis.set_major_formatter(xmajorFormatter)  
-            
+            #self.subfig[i].yaxis.set_major_formatter(xmajorFormatter)
+
             self.subfig[i].legend(loc='upper center', bbox_to_anchor=(0.5, 1.21),fancybox=True, shadow=True, ncol=5)
 
         self.canvas.draw()
-        
+
 class EmitGrowthFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
         self.plot()
-    def plot(self):        
+    def plot(self):
         fileList        = ['fort.24','fort.25']
         xdataList       = [1,1]
         ydataList       = [7,7]
         xyLabelList     = ['Z (m)','Avg emit growth in X and Y']
-        
+
         lineType = ['r-','b--']
-        
+
         try:
             fin1 = open(fileList[0],'r')
         except:
@@ -519,15 +519,15 @@ class EmitGrowthFrame(PlotBaseFrame):
             y   = [(float(linesList1[k][yId]) + float(linesList2[k][yId]))/2 / start -1 for k in range(len(linesList1))]
         except:
             print("  ERRPR! Can't read data '" + fileList[1] + "'")
-            
+
         self.subfig.cla()
         self.subfig.plot(x, y, lineType[0], linewidth=2, label='emit.growth')
         self.subfig.set_xlabel(xyLabelList[0])
         self.subfig.set_ylabel(xyLabelList[1])
         self.subfig.legend()
-        
+
         self.canvas.draw()
-        
+
 class TemperatureFrame(PlotBaseFrame):
     def __init__(self, parent):
         PlotBaseFrame.__init__(self, parent)
@@ -542,7 +542,7 @@ class TemperatureFrame(PlotBaseFrame):
         plotPath = './post'
         if os.path.exists(plotPath) == False:
             os.makedirs(plotPath)
-            
+
         self.subfig.cla()
         for i in range(1,picNum+1):
             try:
@@ -550,7 +550,7 @@ class TemperatureFrame(PlotBaseFrame):
             except:
                 print( "  ERRPR! Can't open file '" + arg[i] + "'")
                 return
-    
+
             linesList  = fin.readlines()
             fin .close()
             linesList  = [line.split() for line in linesList ]
@@ -558,11 +558,11 @@ class TemperatureFrame(PlotBaseFrame):
             yl=4
             y   = [float(xrt[yl])*float(xrt[yl]) for xrt in linesList]
             self.subfig.plot(x, y, color = col[(i-1)],linestyle=lineType[i-1], linewidth=linew[i-1],label=labelList[i-1])
-            
+
         self.subfig.set_xlabel('T (s)')
         self.subfig.set_ylabel('Temperature')
         self.subfig.legend()
-        
+
         self.canvas.draw()
 
 class PlotHighOrderBaseFrame(tk.Frame):
@@ -580,14 +580,14 @@ class PlotHighOrderBaseFrame(tk.Frame):
         except:
             print(( "  ERROR! Can't open file '" + PlotFileName + "'"))
             return
-        
+
         self.data = np.transpose(self.data)
         for i in range(0,4,2):
             self.data[i] = self.data[i] * 1e3  # from m to mm
-            
+
         self.frame_PlotParticleControl = tk.Frame(self)
         self.frame_PlotParticleControl.pack()
-        
+
         self.label_x    = tk.Label(self.frame_PlotParticleControl, text="Direction:")
         self.label_x.pack(side='left')
 
@@ -596,7 +596,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
                                        width=6,
                                        values=['X (mm)', 'Px (MC)', 'Y (mm)', 'Py (MC)','Z (mm)','Pz (MC)'])
         self.ppc1.pack(fill = 'both',expand =1,side = 'left')
-        
+
         LARGE_FONT= ("Verdana", 12)
         self.button_ppc=tk.Button(self.frame_PlotParticleControl)
         self.button_ppc["text"] = "Plot"
@@ -608,11 +608,11 @@ class PlotHighOrderBaseFrame(tk.Frame):
 
         x   = 0
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.fig = Figure(figsize=(6,5), dpi=100)
         self.subfig = self.fig.add_subplot(111)
         self.subfig.scatter(self.data[x],self.data[y],s=1)
-        
+
         xmajorFormatter = FormatStrFormatter('%2.2E')
         self.subfig.yaxis.set_major_formatter(xmajorFormatter)
         box = self.subfig.get_position()
@@ -625,39 +625,39 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
-        
+
 class PlotMaxFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[0],self.data[y])
-    
+
         axis_format_Z(self.data[0],self.data[y], self.subfig)
-        
+
         self.subfig.set_xlabel('Z (m)')
         if y%2==1:
             self.subfig.set_ylabel('Max '+ self.ppc1.get())
         else:
             self.subfig.set_ylabel('Max '+ self.ppc1.get())
         self.canvas.draw()
-        
-        
+
+
 class PlotHighorderFrame(PlotHighOrderBaseFrame):
-    def __init__(self, parent,ifile):    
+    def __init__(self, parent,ifile):
         PlotHighOrderBaseFrame.__init__(self, parent, ifile)
-        
+
     def plot(self):
         y   = self.ParticleDirec[self.ppc1.get()]
-        
+
         self.subfig.cla()
         self.subfig.plot(self.data[0],self.data[y])
-        
+
         xmajorFormatter = FormatStrFormatter('%2.2E')
         self.subfig.yaxis.set_major_formatter(xmajorFormatter)
 
@@ -671,7 +671,7 @@ class PlotHighorderFrame(PlotHighOrderBaseFrame):
         elif y==6:
             self.subfig.set_ylabel('Energy deviation (MeV)')
         self.canvas.draw()
-        
+
 def axis_format_Z(xData,yData,subfig):
     xMax = np.max(xData)
     xMin = np.min(xData)

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -318,7 +318,7 @@ class PlotBaseFrame(tk.Frame):
         self.subfig = self.fig.add_subplot(111)
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -372,7 +372,7 @@ class PlotFrame(tk.Frame):
         subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
-        canvas.show()
+        canvas.draw()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         toolbar = NavigationToolbar2Tk(canvas, self)
@@ -394,7 +394,7 @@ class OverallFrame(tk.Frame):
         self.subfig.append(self.fig.add_subplot(224))
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)
@@ -619,7 +619,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
 
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import ttk,filedialog
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 
@@ -321,7 +321,7 @@ class PlotBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -375,7 +375,7 @@ class PlotFrame(tk.Frame):
         canvas.show()
         canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        toolbar = NavigationToolbar2TkAgg(canvas, self)
+        toolbar = NavigationToolbar2Tk(canvas, self)
         toolbar.update()
         canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
     
@@ -397,7 +397,7 @@ class OverallFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
     
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
@@ -622,7 +622,7 @@ class PlotHighOrderBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
 
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/ImpactZPlotold.py
+++ b/GUI/src/ImpactZPlotold.py
@@ -353,10 +353,10 @@ class PlotFrame(tk.Frame):
             y = y*1.0e6       # unit convert from (m-rad) to (mm-mrad)
         
         fig = Figure(figsize=(7,5), dpi=100)
-        subfig = fig.add_subplot(111)
-        subfig.plot(x,y)
-        subfig.set_xlabel('Z (m)')
-        subfig.set_ylabel(labelY)
+        self.subfig = fig.add_subplot(111)
+        self.subfig.plot(x,y)
+        self.subfig.set_xlabel('Z (m)')
+        self.subfig.set_ylabel(labelY)
         
         
         xMax = np.max(x)
@@ -368,8 +368,8 @@ class PlotFrame(tk.Frame):
         if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
             self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
         
-        box = subfig.get_position()
-        subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
+        box = self.subfig.get_position()
+        self.subfig.set_position([box.x0*1.3, box.y0*1.1, box.width, box.height])
         
         canvas = FigureCanvasTkAgg(fig, self) 
         canvas.draw()
@@ -678,6 +678,6 @@ def axis_format_Z(xData,yData,subfig):
     yMax = np.max(yData)
     yMin = np.min(yData)
     if (xMax-xMin)>IMPACT_Z_sciMaxLimit or (xMax-xMin)<IMPACT_Z_sciMinLimit:
-        subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.xaxis.set_major_formatter(IMPACT_Z_SciFormatter)
     if (yMax-yMin)>IMPACT_Z_sciMaxLimit or (yMax-yMin)<IMPACT_Z_sciMinLimit:
-        subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)
+        self.subfig.yaxis.set_major_formatter(IMPACT_Z_SciFormatter)

--- a/GUI/src/ImpactZSet.py
+++ b/GUI/src/ImpactZSet.py
@@ -7,71 +7,71 @@ import os,sys
 
 _height=200
 _width =200
-class AdvancedSetFrame(tk.Toplevel):            
+class AdvancedSetFrame(tk.Toplevel):
     def __init__(self, master, kernel, cnf={}, **kw):
         tk.Toplevel.__init__(self, master, cnf, **kw)
         self.title('Set')
-        self.focus_set()  
+        self.focus_set()
         #self.grab_set()
         rowtemp=0
         self.frame1 = tk.LabelFrame(self, height =_height/10, width = _width,
                                           text="Configuration")
         self.frame1.pack(side = 'top')
-        
+
         """Exe path"""
         self.frame_exe = tk.LabelFrame(self.frame1)
         self.frame_exe.grid(row=rowtemp,column=0,rowspan=2,columnspan=2,sticky='w')
         rowtemp+=2
-        
+
         self.frame_input1 = tk.LabelFrame(self.frame_exe,borderwidth=0, highlightthickness=0)
         self.frame_input1.grid(row=0,column=0,columnspan=2,sticky='w')
-        
+
         self.label_exePat    = tk.Label(self.frame_input1, text="mpirun:")
         self.label_exePat.pack(side='left')
         self.entry_exePath = tk.Entry(self.frame_input1, width=45,textvariable=master.MPI_EXE)
         self.entry_exePath.pack(side='left')
-        
+
         self.frame_input = tk.LabelFrame(self.frame_exe,borderwidth=0, highlightthickness=0)
         self.frame_input.grid(row=1,column=0,columnspan=2,sticky='w')
-        
+
         self.label_exePat    = tk.Label(self.frame_input, text="Exe:")
         self.label_exePat.pack(side='left')
         self.entry_exePath = tk.Entry(self.frame_input, width=45,textvariable=master.IMPACT_Z_EXE)
         self.entry_exePath.pack(side='left')
-        
+
         self.button_exePath = tk.Button(self.frame_input)
         self.button_exePath["text"]        = "..."
         self.button_exePath["command"]     = lambda: self.changeExe(master.IMPACT_Z_EXE)
         self.button_exePath.pack(side = 'left')
-        
+
         self.button_exePath.bind("<Enter>", lambda event, h=self.button_exePath: h.configure(bg="#00CD00"))
         self.button_exePath.bind("<Leave>", lambda event, h=self.button_exePath: h.configure(bg="#FFFFFF"))
-        
-        
+
+
         """Flag restart"""
-        self.check_restart  = tk.Checkbutton(self.frame1, 
-                                             text="Restart at previous check point", 
+        self.check_restart  = tk.Checkbutton(self.frame1,
+                                             text="Restart at previous check point",
                                              variable=master.FlagRestart)
         self.check_restart  .grid(row=rowtemp,column=0,columnspan=2,sticky='w')
         rowtemp+=1
-        
+
         """Flag error"""
         self.check_error    = tk.Checkbutton(self.frame1, text="Misalignmnet and rotation error", variable=master.Flagerr)
         self.check_error    .grid(row=rowtemp,column=0,columnspan=2,sticky='w')
         rowtemp+=1
-        
+
         """Flag subcycle"""
         self.check_subcycle  = tk.Checkbutton(self.frame1, text="Sub-cycle", variable=master.FlagSubcycle)
         self.check_subcycle .grid(row=rowtemp,column=0,columnspan=2,sticky='w')
         rowtemp+=1
-        
-        self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
-        rowtemp+=1     
-           
 
-        
         self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
-        rowtemp+=1  
+        rowtemp+=1
+
+
+
+        self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
+        rowtemp+=1
         self.label_mass    = tk.Label(self.frame1, text="Mass (eV)")
         self.entry_mass    = tk.Entry(self.frame1,textvariable=master.ptcMass)
         self.label_mass.grid(row=rowtemp,sticky='W')
@@ -88,14 +88,14 @@ class AdvancedSetFrame(tk.Toplevel):
         self.label_dt1.grid(row=rowtemp,sticky='W')
         self.entry_dt1.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Dimension"""
         self.label_dist    = tk.Label(self.frame1, text="Distribution")
         self.entry_dist    = tk.Entry(self.frame1,textvariable=master.distTypeNumb)
         self.label_dist.grid(row=rowtemp,sticky='W')
         self.entry_dist.grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         '''Type of integrator'''
         self.label_integrator       = tk.Label(self.frame1, text="Integrator")
         self.box_integrator         = ttk.Combobox(self.frame1,textvariable=master.Flagmap,
@@ -105,7 +105,7 @@ class AdvancedSetFrame(tk.Toplevel):
         if kernel=='ImpactT':
             self.box_integrator     .config(state='disabled')
         rowtemp+=1
-        
+
         """Flag diagnostics"""
         self.label_diag     = tk.Label(self.frame1, text="Output")
         self.label_diag     .grid(row=rowtemp,sticky='W')
@@ -113,12 +113,12 @@ class AdvancedSetFrame(tk.Toplevel):
                                            values=['Standard', '95% Emittance'])
         self.box_diag       .grid(row=rowtemp, column=1, sticky='E')
         rowtemp+=1
-        
 
-        
+
+
         self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
         rowtemp+=1
-        
+
         """Open boundary condition"""
         self.label_bc       = tk.Label(self.frame1, text='Boundary')
         self.label_bc       .grid(row=rowtemp,sticky='W')
@@ -131,7 +131,7 @@ class AdvancedSetFrame(tk.Toplevel):
                                                    'Trans-Rect,  Longi-perod'])
         self.box_bc         .grid(row=rowtemp, column=1, sticky='E')
         rowtemp+=1
-        
+
         """Computational domain"""
         self.label_Xrad    = tk.Label(self.frame1, text='X pipe width(m):')
         self.entry_Xrad    = tk.Entry(self.frame1,textvariable=master.Xrad)
@@ -150,27 +150,27 @@ class AdvancedSetFrame(tk.Toplevel):
         rowtemp+=1
         self.t = ttk.Separator(self.frame1, orient=tk.HORIZONTAL).grid(row = rowtemp,column=0,columnspan=2, sticky="we")
         rowtemp+=1
-        
 
-        
+
+
         self.label_Nemission = tk.Label(self.frame1, text='Emission Step')
         self.entry_Nemission = tk.Entry(self.frame1,textvariable=master.Nemission)
         self.label_Nemission .grid(row=rowtemp,sticky='E')
         self.entry_Nemission .grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         self.label_Temission = tk.Label(self.frame1, text='Emission Time')
         self.entry_Temission = tk.Entry(self.frame1,textvariable=master.Temission)
         self.label_Temission .grid(row=rowtemp,sticky='E')
         self.entry_Temission .grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         self.label_Tinitial = tk.Label(self.frame1, text='Initial reference time')
         self.entry_Tinitial = tk.Entry(self.frame1,textvariable=master.Tinitial)
         self.label_Tinitial .grid(row=rowtemp,sticky='E')
         self.entry_Tinitial .grid(row=rowtemp,column=1,sticky='E')
         rowtemp+=1
-        
+
         """Nbunch"""
         self.frame_Nbunch = tk.LabelFrame(self, height =_height/10, width = _width,
                                           text="Multiple Charge State")
@@ -197,7 +197,7 @@ class AdvancedSetFrame(tk.Toplevel):
         self.label_Nbunch3.grid(row=rowtemp,sticky='W')
         self.entry_Nbunch3.grid(row=rowtemp,column=1,sticky='W')
         rowtemp+=1
-        
+
         """Advanced distribution"""
         self.frame_Twiss = tk.LabelFrame(self, height =_height/10, width = _width,
                                           text="Initial Distribution")
@@ -207,37 +207,37 @@ class AdvancedSetFrame(tk.Toplevel):
         self.twiss_s = []
         self.twiss_chara = ["sigma(m)","sigmaP","muxpx",'xScale','PxSacle','x shift','px shift']
         for column in range(7):
-            label = tk.Label(self.frame_Twiss, text=self.twiss_chara[column], 
+            label = tk.Label(self.frame_Twiss, text=self.twiss_chara[column],
                             borderwidth=0,
                             width=twisswidth)
             label.grid(row=0, column=column+1, sticky="ns", padx=1, pady=1)
             self.twiss_s.append(label)
-        
+
         self.twiss_x = []
         self.twiss_xchara = ["X","Y","Z"]
         for row in range(3):
-            label = tk.Label(self.frame_Twiss, text=self.twiss_xchara[row], 
+            label = tk.Label(self.frame_Twiss, text=self.twiss_xchara[row],
                                  borderwidth=0, width=2)
             label.grid(row=row+1, column=0, sticky="ns", padx=1, pady=1)
             self.twiss_x.append(label)
-        
+
         self._twiss = []
         for row in range(3):
             current_row = []
             for column in range(7):
-                label = tk.Entry(self.frame_Twiss, 
-                                 textvariable=master.string_sigma[row][column], 
+                label = tk.Entry(self.frame_Twiss,
+                                 textvariable=master.string_sigma[row][column],
                                  borderwidth=0,
                                  width=twisswidth)
                 label.grid(row=row+1, column=column+1, sticky="ns", padx=2, pady=1)
                 current_row.append(label)
             self._twiss.append(current_row)
-            
+
     def changeExe(self,exePath):
         filename = filedialog.askopenfilename(parent=self)
         if filename=='':
             return
-        
+
         exePath.set(filename)
-        
+
         print(exePath.get())

--- a/GUI/src/LatticeFrame.py
+++ b/GUI/src/LatticeFrame.py
@@ -45,36 +45,36 @@ class LatticeFrame(tk.Frame):
     def __init__(self, master=None, cnf={}, **kw):
         '''See the __init__ for tk.Frame for most of this stuff.'''
         tk.Frame.__init__(self, master, cnf, **kw)
-        self.createWidgets()  
+        self.createWidgets()
 
-    def createWidgets(self): 
+    def createWidgets(self):
         self.lattice_sv = tk.Scrollbar(self, orient=tk.VERTICAL)
         self.lattice_sh = tk.Scrollbar(self, orient=tk.HORIZONTAL)
-  
+
         self.latticeText = tk.Text(self,
                                width = _TextWidth,height=_TextHeight,
                                wrap='none',
                                yscrollcommand=self.lattice_sv.set,
                                xscrollcommand=self.lattice_sh.set)
 
-        self.lattice_sv.config(command=self.latticeText.yview)  
-        self.lattice_sh.config(command=self.latticeText.xview)  
-  
-        self.lattice_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N)  
-        self.lattice_sh.pack(fill="x", expand=1, side=tk.BOTTOM, anchor=tk.N)  
-        self.latticeText.pack(fill="both", expand=1, side=tk.TOP)  
-  
+        self.lattice_sv.config(command=self.latticeText.yview)
+        self.lattice_sh.config(command=self.latticeText.xview)
 
-        self.latticeText.bind("<Control-Key-a>", self.selectText)  
-        self.latticeText.bind("<Control-Key-A>", self.selectText)  
+        self.lattice_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N)
+        self.lattice_sh.pack(fill="x", expand=1, side=tk.BOTTOM, anchor=tk.N)
+        self.latticeText.pack(fill="both", expand=1, side=tk.TOP)
+
+
+        self.latticeText.bind("<Control-Key-a>", self.selectText)
+        self.latticeText.bind("<Control-Key-A>", self.selectText)
         self.latticeText.insert(tk.END,'20.0d0 1 1 0 0.d0 0.12 0.12 /')
 
-    
+
     def get(self, index1, index2=None):
         return self.latticeText.get(index1, index2)
-        
+
     def selectText(self, event):
-        self.latticeText.tag_add(tk.SEL, "1.0", tk.END)  
+        self.latticeText.tag_add(tk.SEL, "1.0", tk.END)
         return 'break'
 
 class LatticeFrameC(tk.Frame):
@@ -83,14 +83,14 @@ class LatticeFrameC(tk.Frame):
         def __init__(self, *args, **kwargs):
             tk.Canvas.__init__(self, *args, **kwargs)
             self.textwidget = None
-    
+
         def attach(self, text_widget):
             self.textwidget = text_widget
-    
+
         def redraw(self, *args):
             '''redraw line numbers'''
             self.delete("all")
-    
+
             i = self.textwidget.index("@0,0")
             while True:
                 dline= self.textwidget.dlineinfo(i)
@@ -99,28 +99,28 @@ class LatticeFrameC(tk.Frame):
                 linenum = str(i).split(".")[0]
                 self.create_text(30,y,anchor="ne", text=linenum)
                 i = self.textwidget.index("%s+1line" % i)
-    
+
     class CustomText(tk.Text):
         def __init__(self, *args, **kwargs):
             tk.Text.__init__(self, *args, **kwargs)
-    
+
             self.tk.eval('''
                 proc widget_proxy {widget widget_command args} {
-    
+
                     # call the real tk widget command with the real args
                     set result [uplevel [linsert $args 0 $widget_command]]
-    
+
                     # generate the event for certain types of commands
                     if {([lindex $args 0] in {insert replace delete}) ||
-                        ([lrange $args 0 2] == {mark set insert}) || 
+                        ([lrange $args 0 2] == {mark set insert}) ||
                         ([lrange $args 0 1] == {xview moveto}) ||
                         ([lrange $args 0 1] == {xview scroll}) ||
                         ([lrange $args 0 1] == {yview moveto}) ||
                         ([lrange $args 0 1] == {yview scroll})} {
-    
+
                         event generate  $widget <<Change>> -when tail
                     }
-    
+
                     # return the result from the real widget command
                     return $result
                 }
@@ -129,29 +129,29 @@ class LatticeFrameC(tk.Frame):
                 rename {widget} _{widget}
                 interp alias {{}} ::{widget} {{}} widget_proxy {widget} _{widget}
             '''.format(widget=str(self)))
-            
+
     def __init__(self, master=None, cnf={}, **kw):
         '''See the __init__ for tk.Frame for most of this stuff.'''
         tk.Frame.__init__(self, master, cnf, **kw)
-        self.createWidgets()  
+        self.createWidgets()
 
-    def createWidgets(self):   
+    def createWidgets(self):
         self.lattice_sv = tk.Scrollbar(self, orient=tk.VERTICAL)
         self.lattice_sh = tk.Scrollbar(self, orient=tk.HORIZONTAL)
-  
+
         self.latticeText = self.CustomText(self,
                                width = _TextWidth,height=_TextHeight,
                                wrap='none',
                                yscrollcommand=self.lattice_sv.set,
                                xscrollcommand=self.lattice_sh.set)
-        
+
         self.latticeText.tag_configure("bigfont", font=("Helvetica", "24", "bold"))
         self.linenumbers = self.TextLineNumbers(self, width=30,height=_TextHeight,)
         self.linenumbers.attach(self.latticeText)
-        
-        self.lattice_sv.config(command=self.latticeText.yview)  
+
+        self.lattice_sv.config(command=self.latticeText.yview)
         self.lattice_sh.config(command=self.latticeText.xview)
-        
+
         self.title = tk.Text(self,width = _TextWidth,height=1,
                                wrap='none',bg='#ededed',borderwidth=0)
         self.titleT()
@@ -159,15 +159,15 @@ class LatticeFrameC(tk.Frame):
         self.lattice_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N)
         self.linenumbers.pack(fill="y",expand=1, side=tk.LEFT,  anchor=tk.N)
         self.lattice_sh.pack(fill="x", expand=1, side=tk.BOTTOM,anchor=tk.N)
-        self.title.pack(fill="both", expand=1, side=tk.TOP) 
-        self.latticeText.pack(fill="both", expand=1, side=tk.TOP)  
-  
+        self.title.pack(fill="both", expand=1, side=tk.TOP)
+        self.latticeText.pack(fill="both", expand=1, side=tk.TOP)
 
-        self.latticeText.bind("<Control-Key-a>", self.selectText)  
+
+        self.latticeText.bind("<Control-Key-a>", self.selectText)
         self.latticeText.bind("<Control-Key-A>", self.selectText)
         self.latticeText.bind("<<Change>>", self._on_change)
         self.latticeText.bind("<Configure>", self._on_change)
-    
+
         self.latticeTextHide = tk.Text(self,
                                width = _TextWidth,height=3,
                                wrap='none')
@@ -175,22 +175,22 @@ class LatticeFrameC(tk.Frame):
 
         self.latticeTextHide.insert(tk.END,'20.0 1 1 0 0.d0 0.12 0.12 /')
         self.update()
-        
+
         for ele in ELEMENT_COLOR.keys():
             self.latticeText.tag_config(ele, foreground=ELEMENT_COLOR[ele])
         self._on_change('change')
-        
+
     def _on_change(self, event):
         self.linenumbers.redraw()
         for ele in ELEMENT_COLOR.keys():
             self.search(self.latticeText,  ele,   ele)
     def get(self, index1, index2=None):
         return self.latticeText.get(index1, index2)
-    
+
     def getHide(self):
         self.updateHide()
         return self.latticeTextHide.get('0.0', tk.END)
-    
+
     def update(self):
         self.latticeText.delete('0.0', tk.END)
         text = self.latticeTextHide.get('1.0', tk.END).splitlines()
@@ -198,7 +198,7 @@ class LatticeFrameC(tk.Frame):
             if line.strip()!='':
                 a=self.convertNtoW(line)
                 self.latticeText.insert('end',a)
-            
+
     def updateHide(self):
         self.latticeTextHide.delete('0.0', tk.END)
         text = self.latticeText.get('1.0', tk.END).splitlines()
@@ -206,11 +206,11 @@ class LatticeFrameC(tk.Frame):
             if line.strip()!='':
                 a=self.convertWtoN(line)
                 self.latticeTextHide.insert('end',a)
-       
+
     def selectText(self, event):
-        self.latticeText.tag_add(tk.SEL, "1.0", tk.END)  
+        self.latticeText.tag_add(tk.SEL, "1.0", tk.END)
         return 'break'
-    
+
     def convertNtoW(self,s1):
         strSet = s1.split()
         try:
@@ -224,8 +224,8 @@ class LatticeFrameC(tk.Frame):
             return wordFormat+'\n'
         except:
             return s1+'\n'
-            
-    
+
+
     def convertWtoN(self,s1):
         strSet = s1.split()
         try:
@@ -235,7 +235,7 @@ class LatticeFrameC(tk.Frame):
             return numberFormat+'\n'
         except:
             return s1+'\n'
-        
+
     def titleT(self):
         self.title.config(state='normal')
         wordFormat = '{:<10}'.format('Name')
@@ -256,7 +256,7 @@ class LatticeFrameC(tk.Frame):
         self.title.delete('0.0', tk.END)
         self.title.insert('0.0',wordFormat)
         self.title.config(state='disabled')
-    
+
     def search(self, text_widget, keyword, tag):
         pos = '1.0'
         while True:
@@ -265,7 +265,7 @@ class LatticeFrameC(tk.Frame):
                 break
             pos = '{}+{}c'.format(idx, len(keyword))
             text_widget.tag_add(tag, idx, pos)
-            
+
 class ConsoleText(tk.Text):
     '''A Tkinter Text widget that provides a scrolling display of console stdout.'''
 
@@ -294,17 +294,17 @@ class ConsoleText(tk.Text):
 
         #self.tag_configure('STDOUT',background='black',foreground='white')
         #self.tag_configure('STDERR',background='black',foreground='red')
-        
+
         #self.console_sv = tk.Scrollbar(master, orient=tk.VERTICAL)
         #self.console_sv.config(command=self.yview)
-        #self.console_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N) 
+        #self.console_sv.pack(fill="y", expand=0, side=tk.RIGHT, anchor=tk.N)
         self.width = _TextWidth
         self.height=_TextHeight,
         self.config(state=tk.NORMAL)
         self.bind("<1>", lambda event: self.focus_set())
         #self.bind('<Key>',lambda e: 'break') #ignore all key presses
 
-         
+
     def start(self):
 
         if self.started:
@@ -345,4 +345,3 @@ class ConsoleText(tk.Text):
         self.see('end')
 
         self.write_lock.release()
-    

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -52,7 +52,9 @@ def is_mass_matched(bunch_list):
 
 def bunch_text(bunch_list):
     """Create a text string to describe the bunch list for titles."""
-    if len(bunch_list) == 1:
+    if get_bunch_count() == 1:
+        return 'single bunch'
+    elif len(bunch_list) == 1:
         return f'bunch {bunch_list[0]}'
     elif len(bunch_list) == get_bunch_count():
         return 'all bunches'
@@ -63,6 +65,13 @@ def bunch_text(bunch_list):
                 + ', '.join([str(bunch) for bunch in bunch_list[:-1]])
                 + ' and '
                 + str(bunch_list[-1]))
+
+def check_bunch_list(bunch_list):
+    """Remove any bunches from the list that don't exist."""
+    max_bunch = get_bunch_count()
+    valid_bunches = [bunch for bunch in bunch_list if bunch <= max_bunch]
+    invalid_bunches = [bunch for bunch in bunch_list if bunch > max_bunch]
+    return valid_bunches, invalid_bunches
 
 def read_input_file(filename):
     """Read input file and return list of input lines, excluding comments."""
@@ -368,6 +377,9 @@ def add_plot_margins(axes, margin):
 def plot_all(bunch_list):
     """Run and save all plots consecutively."""
     full_bunch_list = list(range(1, int(get_bunch_count()) + 1))
+    bunch_list, invalid_bunches = check_bunch_list(bunch_list)
+    if invalid_bunches:
+        print(f'Skipping invalid bunches: {invalid_bunches}')
     print('Loading experimental data...')
     try:
         experimental_results = load_experimental_results()
@@ -436,12 +448,14 @@ def plot_all(bunch_list):
             title=f'Initial phase space for {bunch_text(bunch_list)}')
         figure.savefig('phase-space-initial')
         matplotlib.pyplot.close(figure)
-        for bunch in full_bunch_list:
-            figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
-            plot_phase_spaces(axes, full_data[bunch-1], [bunch], grid_size=300,
-                title=f'Initial phase space for {bunch_text([bunch])}')
-            figure.savefig(f'phase-space-initial-bunch{bunch}')
-            matplotlib.pyplot.close(figure)
+        if len(full_bunch_list) > 1:
+            for bunch in full_bunch_list:
+                figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
+                plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                    title=f'Initial phase space for {bunch_text([bunch])}',
+                    grid_size=300)
+                figure.savefig(f'phase-space-initial-bunch{bunch}')
+                matplotlib.pyplot.close(figure)
         print('Plotting initial energy spectra...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
         plot_bunch_energies(axes, data, bunch_list, bins=300,
@@ -468,12 +482,14 @@ def plot_all(bunch_list):
             title=f'Final phase space for {bunch_text(bunch_list)}')
         figure.savefig('phase-space-final')
         matplotlib.pyplot.close(figure)
-        for bunch in full_bunch_list:
-            figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
-            plot_phase_spaces(axes, full_data[bunch-1], [bunch], grid_size=300,
-                title=f'Final phase space for {bunch_text([bunch])}')
-            figure.savefig(f'phase-space-final-bunch{bunch}')
-            matplotlib.pyplot.close(figure)
+        if len(full_bunch_list) > 1:
+            for bunch in full_bunch_list:
+                figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
+                plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                    title=f'Final phase space for {bunch_text([bunch])}',
+                    grid_size=300)
+                figure.savefig(f'phase-space-final-bunch{bunch}')
+                matplotlib.pyplot.close(figure)
         print('Plotting final energy spectra...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
         plot_bunch_energies(axes, data,  bunch_list, bins=300,
@@ -511,14 +527,15 @@ def plot_all(bunch_list):
                                   grid_size=300)
                 figure.savefig(f'phase-space-{filenumber}')
                 matplotlib.pyplot.close(figure)
-                for bunch in full_bunch_list:
-                    figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                    plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                                      title=(f'Phase space at z = {location} '
-                                             f'for {bunch_text([bunch])}'),
-                                      grid_size=300)
-                    figure.savefig(f'phase-space-{filenumber}-bunch{bunch}')
-                    matplotlib.pyplot.close(figure)
+                if len(full_bunch_list) > 1:
+                    for bunch in full_bunch_list:
+                        figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
+                        plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                                        title=(f'Phase space at z = {location} '
+                                                f'for {bunch_text([bunch])}'),
+                                        grid_size=300)
+                        figure.savefig(f'phase-space-{filenumber}-bunch{bunch}')
+                        matplotlib.pyplot.close(figure)
                 print(f'Plotting BPM {filenumber} energy spectra...')
                 figure, axes = matplotlib.pyplot.subplots(dpi=300)
                 plot_bunch_energies(axes, data, bunch_list, bins=300,

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot
 import numpy
 import sys
 import pathlib
+import copy
 
 def get_input_filename(bunch):
     """Return the filename of the input file for a particular bunch."""
@@ -348,7 +349,7 @@ def plot_phase_space(axes, xdata, ydata, xlabel, ylabel, grid_size=100):
 
 def plot_phase_space_hist2d(axes, x, y, grid_size=100):
     """Plot the 2d histogram part of the phase space plot."""
-    colour_map = matplotlib.cm.get_cmap('jet')
+    colour_map = copy.copy(matplotlib.cm.get_cmap("jet"))
     colour_map.set_under('white', 0.)
     return axes.hist2d(x, y, bins=grid_size, cmap=colour_map, cmin=1)
 
@@ -383,7 +384,7 @@ def plot_bunch_energies(axes, data, bunch_list, title=None, bins=100):
     handles, labels = axes.get_legend_handles_labels()
     handles.reverse()
     labels.reverse()
-    axes.legend(handles, labels)
+    axes.legend(handles, labels, loc='upper right')
 
 def plot_total_energy(axes, combined_data, bunch_list, title=None, bins=100):
     """Plot total energy spectrum histogram on log scale."""
@@ -471,6 +472,9 @@ def plot_all(bunch_list, z_offset=None):
     except FileNotFoundError as err:
         print(f'Phase space data file not found: {err}')
         print('Skipping initial phase space step.')
+    except IndexError as err:
+        print(f'Error processing phase space data: {err}')
+        print('Skipping initial phase space step.')
     else:
         data = [full_data[bunch-1] for bunch in bunch_list]
         combined_data = combine_phase_space_data(data)
@@ -504,6 +508,9 @@ def plot_all(bunch_list, z_offset=None):
         full_data = load_phase_space_data(50, full_bunch_list, z_offset)
     except FileNotFoundError as err:
         print(f'Phase space data file not found: {err}')
+        print('Skipping final phase space step.')
+    except IndexError as err:
+        print(f'Error processing phase space data: {err}')
         print('Skipping final phase space step.')
     else:
         data = [full_data[bunch-1] for bunch in bunch_list]
@@ -548,6 +555,9 @@ def plot_all(bunch_list, z_offset=None):
                                                   z_offset)
             except FileNotFoundError as err:
                 print(f'BPM data file not found: {err}')
+                print('Skipping this BPM plot step.')
+            except IndexError as err:
+                print(f'Error processing phase space data: {err}')
                 print('Skipping this BPM plot step.')
             else:
                 data = [full_data[bunch-1] for bunch in bunch_list]

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -143,7 +143,9 @@ def shift_z(data, z_offset, z_col=1):
 
 def calculate_energies(data, bunch):
     """Calculate the energies for per-bunch data and save as an extra column."""
-    gamma = numpy.sqrt(1 + numpy.square(data.T[5]))
+    gamma = numpy.sqrt(1 + numpy.square(data.T[1])
+                         + numpy.square(data.T[3])
+                         + numpy.square(data.T[5]))
     mass = get_mass(get_input_filename(bunch))
     W = (gamma - 1)*mass
     new_data = numpy.zeros((data.shape[0], data.shape[1]+1))

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -1,0 +1,549 @@
+import matplotlib
+import matplotlib.pyplot
+import numpy
+import sys
+import pathlib
+
+def get_input_filename(bunch):
+    """Return the filename of the input file for a particular bunch."""
+    if bunch == 1:
+        filename = 'ImpactT.in'
+    else:
+        filename = f'ImpactT{bunch}.in'
+    if pathlib.Path(filename+'.rendered').is_file():
+        filename += '.rendered'
+    return filename
+
+def get_bunch_count():
+    """Get the number of bunches from the first input file."""
+    input = read_input_file(get_input_filename(1))
+    return int(input[1].split()[2])
+
+def get_lattice():
+    """Get the lattice from the first input file as a list of lists."""
+    input = read_input_file(get_input_filename(1))
+    return [line.split() for line in input[9:]]
+
+def get_bpms(lattice):
+    """Get the location and file number of all BPMs as a list of tuples."""
+    return [(str(float(elem[4])*1000) + ' mm', int(elem[2]))
+            for elem in lattice if elem[3]=='-2']
+
+def get_bunch_counts(bunch_list):
+    """Get the particle counts for each bunch as an array."""
+    input_filenames = [get_input_filename(bunch) for bunch in bunch_list]
+    counts = [get_particle_count(filename) for filename in input_filenames]
+    return numpy.array(counts)
+
+def get_particle_count(filename):
+    """Get the macroparticle count from a given input file."""
+    input = read_input_file(filename)
+    return int(input[2].split()[1])
+
+def get_mass(filename):
+    """Get the particle mass from a given input file."""
+    input = read_input_file(filename)
+    return float(input[8].split()[2])
+
+def is_mass_matched(bunch_list):
+    """Check whether the particle mass values are the same for given bunches."""
+    mass = [get_mass(get_input_filename(bunch)) for bunch in bunch_list]
+    return len(set(mass)) == 1
+
+def bunch_text(bunch_list):
+    """Create a text string to describe the bunch list for titles."""
+    if len(bunch_list) == 1:
+        return f'bunch {bunch_list[0]}'
+    elif len(bunch_list) == get_bunch_count():
+        return 'all bunches'
+    elif bunch_list[-1] - bunch_list[0] + 1 == len(bunch_list):
+        return f'bunches {bunch_list[0]} to {bunch_list[-1]}'
+    else:
+        return ('bunches '
+                + ', '.join([str(bunch) for bunch in bunch_list[:-1]])
+                + ' and '
+                + str(bunch_list[-1]))
+
+def read_input_file(filename):
+    """Read input file and return list of input lines, excluding comments."""
+    with open(filename, 'r') as f:
+        return [line.strip() for line in f.readlines() if line[0] != '!']
+
+def load_data_from_file(filename, header=0):
+    """Load data from a text file, skipping header rows, and return an array."""
+    with open(filename, 'r') as f:
+        data = [[float(value) for value in line.split()]
+                for line in f.readlines()[header:]]
+    return numpy.array(data)
+
+def load_experimental_results(filename='experimental_data.txt'):
+    """Load z, rms beam size and error values (m) from file as an array."""
+    return load_data_from_file(filename, header=1)
+
+def load_statistics_data(bunch_list):
+    """Load x and y data per bunch from statistics files as arrays."""
+    xdata = []
+    ydata = []
+    for bunch in bunch_list:
+        xdata.append(load_data_from_file(f'fort.{bunch}024'))
+        ydata.append(load_data_from_file(f'fort.{bunch}025'))
+    return numpy.array(xdata), numpy.array(ydata)
+
+def load_bunch_count_data():
+    """Load bunch counts vs time from `fort.11` as an array."""
+    data = load_data_from_file('fort.11')
+    return numpy.delete(data, 0, 1) # remove first column (time-step #)
+
+def load_phase_space_data(filenumber, bunch_list):
+    """Load phase space data per bunch as a list of arrays."""
+    data = []
+    for bunch in bunch_list:
+        this_data = load_data_from_file(f'fort.{filenumber+bunch-1}')
+        data.append(calculate_energies(this_data, bunch))
+    return data
+
+def calculate_energies(data, bunch):
+    """Calculate the energies for per-bunch data and save as an extra column."""
+    gamma = numpy.sqrt(1 + numpy.square(data.T[5]))
+    mass = get_mass(get_input_filename(bunch))
+    W = (gamma - 1)*mass
+    new_data = numpy.zeros((data.shape[0], data.shape[1]+1))
+    new_data[:,:-1] = data
+    new_data[:,-1] = W
+    return new_data
+
+def combine_bunch_values(data, bunch_list):
+    """Combine values of separate bunches into a single summary dataset."""
+    if len(data) == 1:
+        return data[0]
+    npt = numpy.array(get_bunch_counts(bunch_list))
+    # Decompose data
+    t_data = data[:,:,0]
+    z0_data = data[:,:,1]
+    x0_data = data[:,:,2]
+    xrms_data = data[:,:,3]
+    px0_data = data[:,:,4]
+    pxrms_data = data[:,:,5]
+    xpx_data = -data[:,:,6]
+    # All t data should be the same
+    t = t_data[0]
+    if not all([row == t.tolist() for row in t_data.tolist()]):
+        raise ValueError('Time step values not in sync across bunches.')
+    # Centroids can be combined by a weighted mean
+    z0 = numpy.sum(z0_data.T.dot(numpy.diag(npt)).T, 0)/npt.sum()
+    x0 = numpy.sum(x0_data.T.dot(numpy.diag(npt)).T, 0)/npt.sum()
+    px0 = numpy.sum(px0_data.T.dot(numpy.diag(npt)).T, 0)/npt.sum()
+    # To combine rms values we need the weighted sum of squares
+    sumsqx = numpy.sum(numpy.square(xrms_data).T.dot(numpy.diag(npt)).T
+                       + numpy.square(x0_data).T.dot(numpy.diag(npt)).T, 0)
+    sumsqpx = numpy.sum(numpy.square(pxrms_data).T.dot(numpy.diag(npt)).T
+                        + numpy.square(px0_data).T.dot(numpy.diag(npt)).T, 0)
+    sumxpx = numpy.sum((xpx_data + x0_data*px0_data).T.dot(numpy.diag(npt)).T, 0)
+    xrms = numpy.sqrt(sumsqx/npt.sum() - numpy.square(x0))
+    pxrms = numpy.sqrt(sumsqpx/npt.sum() - numpy.square(px0))
+    xpx = sumxpx/npt.sum() - (x0 * px0)
+    epx = numpy.sqrt(xrms*xrms * pxrms*pxrms - xpx*xpx)
+    # Return combined data as an array
+    return numpy.array([t, z0, x0, xrms, px0, pxrms, -xpx, epx]).T
+
+def combine_phase_space_data(data):
+    """Combine per-bunch phase space data into single array."""
+    return numpy.concatenate(data)
+
+def get_xdata(data, xaxis):
+    """Return data for the given x-axis: time t (ns) or location z (mm)."""
+    if xaxis == 't':
+        return data.T[0]*1.0e9
+    elif xaxis == 'z':
+        return data.T[1]*1.0e3
+    else:
+        raise ValueError(f'Invalid xaxis specifier: {xaxis}')
+
+def get_xlabel(xaxis):
+    """Return label for the given x-axis: time t (ns) or location z (mm)."""
+    if xaxis == 't':
+        return 'Time (ns)'
+    elif xaxis == 'z':
+        return 'Average z-position (mm)'
+    else:
+        raise ValueError(f'Invalid xaxis specifier: {xaxis}')
+
+def plot_beam_size(axes, data, bunch_list, xaxis='z', title=None,
+                   experiment_data=None, combined_data=None):
+    """Create a plot of beam size per bunch."""
+    if xaxis == 't' and experiment_data is not None:
+        print('Cannot plot experimental results against time t.')
+        print('Continuing without experimental results.')
+        experiment_data = None
+    if not title:
+        title = 'Beam sizes for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    axes.set_xlabel(get_xlabel(xaxis))
+    axes.set_ylabel('Beam size (mm)')
+    if combined_data is None:
+        combined_data = combine_bunch_values(data, bunch_list)
+    if experiment_data is not None:
+        plot_beam_size_experimental(axes, experiment_data)
+    for i in range(len(bunch_list)):
+        plot_beam_size_single(axes, data[i], xaxis, '--',
+                              label=f'Bunch {bunch_list[i]} rms')
+    if len(bunch_list) > 1:
+        plot_beam_size_single(axes, combined_data, xaxis, 'r-',
+                              label=f'Combined rms')
+    axes.legend(fontsize='x-small')
+
+def plot_beam_size_experimental(axes, data):
+    """Plot experimental data points with error bars"""
+    z = data.T[0]*1.0e3
+    rms = data.T[1]*1.0e3
+    error = data.T[2]*1.0e3
+    axes.errorbar(z, rms, yerr=error,
+                  fmt='ko', markersize=2.0, elinewidth=0.5, capsize=1.0,
+                  label='Experimental rms')
+
+def plot_beam_size_single(axes, data, xaxis, fmt, label):
+    """Plot the rms beam size for the given data onto the given axes."""
+    x = get_xdata(data, xaxis)
+    rms = data.T[3]*1.0e3
+    axes.plot(x, rms, fmt, linewidth=1, label=label)
+
+def plot_emittance(axes, xdata, ydata, bunch_list, xaxis='t', title=None,
+                   combined_xdata=None, combined_ydata=None):
+    """Create a plot of average x and y emittance per bunch."""
+    if not title:
+        title = 'Emittance for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    axes.set_xlabel(get_xlabel(xaxis))
+    axes.set_ylabel('Normalised rms emittance (π mm mrad)')
+    for i in range(len(bunch_list)):
+        plot_emittance_single(axes, xdata[i], ydata[i], xaxis,
+                              '--', label=f'Bunch {bunch_list[i]}')
+    if len(bunch_list) > 1:
+        if combined_xdata is None:
+            combined_xdata = combine_bunch_values(xdata, bunch_list)
+        if combined_ydata is None:
+            combined_ydata = combine_bunch_values(ydata, bunch_list)
+        plot_emittance_single(axes, combined_xdata, combined_ydata, xaxis,
+                              'r-', label='Combined')
+    axes.legend(fontsize='x-small')
+
+def plot_emittance_single(axes, xdata, ydata, xaxis, fmt, label):
+    """Plot the average x and y emittance onto the given axes."""
+    x = get_xdata(xdata, xaxis)
+    emittance = (xdata.T[7] + ydata.T[7])/2 * 1e6
+    axes.plot(x, emittance, fmt, linewidth=1, label=label)
+
+def plot_emittance_growth(axes, xdata, ydata, bunch_list, xaxis='t', title=None,
+                          combined_xdata=None, combined_ydata=None):
+    """Create a plot of average x and y emittance growth per bunch."""
+    if not title:
+        title = 'Emittance growth for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    axes.set_xlabel(get_xlabel(xaxis))
+    axes.set_ylabel('Average emittance growth in x and y (relative)')
+    for i in range(len(bunch_list)):
+        plot_emittance_growth_single(axes, xdata[i], ydata[i], xaxis,
+                                     '--', label=f'Bunch {bunch_list[i]}')
+    if len(bunch_list) > 1:
+        if combined_xdata is None:
+            combined_xdata = combine_bunch_values(xdata, bunch_list)
+        if combined_ydata is None:
+            combined_ydata = combine_bunch_values(ydata, bunch_list)
+        plot_emittance_growth_single(axes, combined_xdata, combined_ydata, xaxis,
+                                     'r-', label=f'Combined')
+    axes.legend(fontsize='x-small')
+
+def plot_emittance_growth_single(axes, xdata, ydata, xaxis, fmt, label):
+    """Plot the average x and y emittance growth onto the given axes."""
+    x = get_xdata(xdata, xaxis)
+    emittance = (xdata.T[7] + ydata.T[7])/2 * 1e6
+    initial_emittance = max(emittance[0], 1e-10)
+    growth = emittance/initial_emittance - 1
+    axes.plot(x, growth, fmt, linewidth=1, label=label)
+
+def plot_bunch_count(axes, data, bunch_list, xaxis='t', title=None):
+    """Plot the number of particles per bunch against 't' or 'z'."""
+    if not title:
+        title = 'Bunch counts for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    x = get_xdata(data, xaxis)
+    xlabel = get_xlabel(xaxis)
+    counts = data.T[3:][[bunch - 1 for bunch in bunch_list]]
+    axes.stackplot(x, counts, labels=[f'Bunch {bunch}' for bunch in bunch_list])
+    axes.set_xlim(left=0.0)
+    axes.set_xlabel(xlabel)
+    axes.set_ylabel('Number of macroparticles')
+    axes.legend()
+
+def plot_phase_spaces(axes, data, bunch_list, title=None, grid_size=100):
+    """Plot four phase spaces onto the given array of axes."""
+    if not title:
+        title = 'Phase space for ' + bunch_text(bunch_list)
+    axes[0,0].figure.suptitle(title)
+    x = data.T[0]
+    px = data.T[1]
+    y = data.T[2]
+    py = data.T[3]
+    z = data.T[4]
+    pz = data.T[5]
+    W = data.T[6]
+    xp = px/pz
+    yp = py/pz
+    plot_phase_space(axes[0,0], x*1e3, xp*1e3, 'x (mm)', 'x` (mrad)', grid_size)
+    plot_phase_space(axes[0,1], y*1e3, yp*1e3, 'y (mm)', 'y` (mrad)', grid_size)
+    plot_phase_space(axes[1,1], x*1e3, y*1e3, 'x (mm)', 'y (mm)', grid_size)
+    plot_phase_space(axes[1,0], z*1e3, W/1e6, 'z (mm)', 'Energy (MeV)', grid_size)
+
+def plot_phase_space(axes, xdata, ydata, xlabel, ylabel, grid_size=100):
+    """Plot a single phase space onto the given axes."""
+    if grid_size < 10:
+        grid_size = 10
+    axes.set_xlabel(xlabel, fontsize='x-small')
+    axes.set_ylabel(ylabel, fontsize='x-small')
+    axes.tick_params(labelsize='xx-small')
+    hist2d = plot_phase_space_hist2d(axes, xdata, ydata, grid_size)
+    add_plot_margins(axes, 0.1)
+    plot_phase_space_hist1d(axes, hist2d, grid_size)
+
+def plot_phase_space_hist2d(axes, x, y, grid_size=100):
+    """Plot the 2d histogram part of the phase space plot."""
+    colour_map = matplotlib.cm.get_cmap('jet')
+    colour_map.set_under('white', 0.)
+    return axes.hist2d(x, y, bins=grid_size, cmap=colour_map, cmin=1)
+
+def plot_phase_space_hist1d(axes, hist2d, grid_size=100):
+    """Plot 1d histograms on the axes of the phase space plot."""
+    hist, xedges, yedges, _ = hist2d
+    xmin, xmax, ymin, ymax = xedges[0], xedges[-1], yedges[0], yedges[-1]
+    x0, x1, y0, y1 = axes.axis()
+    xscale = numpy.array(range(grid_size)) / grid_size * (xmax - xmin) + xmin
+    yscale = numpy.array(range(grid_size)) / grid_size * (ymax - ymin) + ymin
+    xhist = numpy.nansum(hist, 1)
+    yhist = numpy.nansum(hist, 0)
+    xhist_scaled = xhist / xhist.max() * (y1 - y0) * 0.2 + y0
+    yhist_scaled = yhist / yhist.max() * (x1 - x0) * 0.2 + x0
+    axes.plot(xscale, xhist_scaled, color='green', linewidth=0.75)
+    axes.plot(yhist_scaled, yscale, color='green', linewidth=0.75)
+
+def plot_bunch_energies(axes, data, bunch_list, title=None, bins=100):
+    """Plot per-bunch energy spectra histograms."""
+    if not title:
+        title = 'Energy spectra for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    W = [bunch.T[6]/1e6 for bunch in data]
+    if len(bunch_list) > 1:
+        axes.hist(numpy.concatenate(W), bins=bins, label='Total',
+                  histtype='stepfilled', linewidth=1.0,
+                  color='red', facecolor=(1,0,0,0.1), edgecolor=(1,0,0,1.0))
+    axes.hist(W, bins=bins, histtype='stepfilled', alpha=0.5,
+              label=[f'Bunch {bunch}' for bunch in bunch_list])
+    axes.set_xlabel('Energy (MeV)')
+    axes.set_ylabel('Number of macroparticles')
+    handles, labels = axes.get_legend_handles_labels()
+    handles.reverse()
+    labels.reverse()
+    axes.legend(handles, labels)
+
+def plot_total_energy(axes, combined_data, bunch_list, title=None, bins=100):
+    """Plot total energy spectrum histogram on log scale."""
+    if not title:
+        title = 'Total energy spectrum for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    W = combined_data.T[6]/1e6
+    axes.hist(W, bins=bins, histtype='stepfilled', linewidth=1.0,
+              color='red', facecolor=(1,0,0,0.1), edgecolor=(1,0,0,1.0))
+    axes.set_xlabel('Energy (MeV)')
+    axes.set_ylabel('Number of macroparticles')
+    axes.set_yscale('log')
+
+def add_plot_margins(axes, margin):
+    """Adjust the axis limits to include a margin around the data."""
+    xmin, xmax = axes.get_xlim()
+    ymin, ymax = axes.get_ylim()
+    xmargin = margin*(xmax - xmin)
+    ymargin = margin*(ymax - ymin)
+    axes.set_xlim(xmin - xmargin, xmax + xmargin)
+    axes.set_ylim(ymin - ymargin, ymax + ymargin)
+
+def plot_all(bunch_list):
+    """Run and save all plots consecutively."""
+    full_bunch_list = list(range(1, int(get_bunch_count()) + 1))
+    print('Loading experimental data...')
+    try:
+        experimental_results = load_experimental_results()
+    except FileNotFoundError as err:
+        print(f'Experimental results data file not found: {err}')
+        print('Continuing without experimental data.')
+        experimental_results = None
+    print('Loading statistical data...')
+    try:
+        xdata, ydata = load_statistics_data(bunch_list)
+    except FileNotFoundError as err:
+        print(f'Statistical data file not found: {err}')
+        print('Skipping statistical plots.')
+    else:
+        combined_xdata = combine_bunch_values(xdata, bunch_list)
+        combined_ydata = combine_bunch_values(ydata, bunch_list)
+        print('Plotting beam size...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_beam_size(axes, xdata, bunch_list, combined_data=combined_xdata)
+        figure.savefig('beam-size')
+        matplotlib.pyplot.close(figure)
+        if experimental_results is not None:
+            figure, axes = matplotlib.pyplot.subplots(dpi=300)
+            plot_beam_size(axes, xdata, bunch_list,
+                           combined_data=combined_xdata,
+                           experiment_data=experimental_results)
+            figure.savefig('beam-size-vs-experiment')
+            matplotlib.pyplot.close(figure)
+        print('Plotting emittance...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_emittance(axes, xdata, ydata, bunch_list,
+                       combined_xdata=combined_xdata,
+                       combined_ydata=combined_ydata)
+        figure.savefig('emittance')
+        matplotlib.pyplot.close(figure)
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_emittance_growth(axes, xdata, ydata, bunch_list,
+                              combined_xdata=combined_xdata,
+                              combined_ydata=combined_ydata)
+        figure.savefig('emittance-growth')
+        matplotlib.pyplot.close(figure)
+    print('Loading bunch count data...')
+    try:
+        data = load_bunch_count_data()
+    except FileNotFoundError as err:
+        print(f'Bunch count data file not found: {err}')
+        print('Skipping bunch count plot.')
+    else:
+        print('Plotting bunch counts...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_bunch_count(axes, data, bunch_list)
+        figure.savefig('bunch-count')
+        matplotlib.pyplot.close(figure)
+    print('Loading initial phase space data...')
+    try:
+        full_data = load_phase_space_data(40, full_bunch_list)
+    except FileNotFoundError as err:
+        print(f'Phase space data file not found: {err}')
+        print('Skipping initial phase space step.')
+    else:
+        data = [full_data[bunch-1] for bunch in bunch_list]
+        combined_data = combine_phase_space_data(data)
+        print('Plotting initial phase space data...')
+        figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
+        plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
+            title=f'Initial phase space for {bunch_text(bunch_list)}')
+        figure.savefig('phase-space-initial')
+        matplotlib.pyplot.close(figure)
+        for bunch in full_bunch_list:
+            figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
+            plot_phase_spaces(axes, full_data[bunch-1], [bunch], grid_size=300,
+                title=f'Initial phase space for {bunch_text([bunch])}')
+            figure.savefig(f'phase-space-initial-bunch{bunch}')
+            matplotlib.pyplot.close(figure)
+        print('Plotting initial energy spectra...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_bunch_energies(axes, data, bunch_list, bins=300,
+            title=f'Initial energy spectra for {bunch_text(bunch_list)}')
+        figure.savefig('energies-initial')
+        matplotlib.pyplot.close(figure)
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_total_energy(axes, combined_data, bunch_list, bins=300,
+            title=f'Initial total energy spectrum for {bunch_text(bunch_list)}')
+        figure.savefig('energy-initial')
+        matplotlib.pyplot.close(figure)
+    print('Loading final phase space data...')
+    try:
+        full_data = load_phase_space_data(50, full_bunch_list)
+    except FileNotFoundError as err:
+        print(f'Phase space data file not found: {err}')
+        print('Skipping final phase space step.')
+    else:
+        data = [full_data[bunch-1] for bunch in bunch_list]
+        combined_data = combine_phase_space_data(data)
+        print('Plotting final phase space data...')
+        figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
+        plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
+            title=f'Final phase space for {bunch_text(bunch_list)}')
+        figure.savefig('phase-space-final')
+        matplotlib.pyplot.close(figure)
+        for bunch in full_bunch_list:
+            figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
+            plot_phase_spaces(axes, full_data[bunch-1], [bunch], grid_size=300,
+                title=f'Final phase space for {bunch_text([bunch])}')
+            figure.savefig(f'phase-space-final-bunch{bunch}')
+            matplotlib.pyplot.close(figure)
+        print('Plotting final energy spectra...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_bunch_energies(axes, data,  bunch_list, bins=300,
+            title=f'Final energy spectra for {bunch_text(bunch_list)}')
+        figure.savefig('energies-final')
+        matplotlib.pyplot.close(figure)
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        plot_total_energy(axes, combined_data, bunch_list, bins=300,
+            title=f'Final total energy spectrum for {bunch_text(bunch_list)}')
+        figure.savefig('energy-final')
+        matplotlib.pyplot.close(figure)
+    print('Getting list of BPMs...')
+    try:
+        lattice = get_lattice()
+        bpm_list = get_bpms(lattice)
+    except FileNotFoundError as err:
+        print(f'Input file not found: {err}')
+        print('Skipping BPM plot steps.')
+    else:
+        for location, filenumber in bpm_list:
+            print(f'Loading BPM {filenumber} phase space data...')
+            try:
+                full_data = load_phase_space_data(filenumber, full_bunch_list)
+            except FileNotFoundError as err:
+                print(f'BPM data file not found: {err}')
+                print('Skipping this BPM plot step.')
+            else:
+                data = [full_data[bunch-1] for bunch in bunch_list]
+                combined_data = combine_phase_space_data(data)
+                print(f'Plotting BPM {filenumber} phase space data...')
+                figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
+                plot_phase_spaces(axes, combined_data, bunch_list,
+                                  title=(f'Phase space at z = {location} '
+                                         f'for {bunch_text(bunch_list)}'),
+                                  grid_size=300)
+                figure.savefig(f'phase-space-{filenumber}')
+                matplotlib.pyplot.close(figure)
+                for bunch in full_bunch_list:
+                    figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
+                    plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                                      title=(f'Phase space at z = {location} '
+                                             f'for {bunch_text([bunch])}'),
+                                      grid_size=300)
+                    figure.savefig(f'phase-space-{filenumber}-bunch{bunch}')
+                    matplotlib.pyplot.close(figure)
+                print(f'Plotting BPM {filenumber} energy spectra...')
+                figure, axes = matplotlib.pyplot.subplots(dpi=300)
+                plot_bunch_energies(axes, data, bunch_list, bins=300,
+                                    title=(f'BPM {filenumber} energy spectra '
+                                           f'for {bunch_text(bunch_list)}'))
+                figure.savefig(f'energies-{filenumber}')
+                matplotlib.pyplot.close(figure)
+                figure, axes = matplotlib.pyplot.subplots(dpi=300)
+                plot_total_energy(axes, combined_data, bunch_list, bins=300,
+                                  title=(f'BPM {filenumber} energy spectrum '
+                                         f'for {bunch_text(bunch_list)}'))
+                figure.savefig(f'energy-{filenumber}')
+                matplotlib.pyplot.close(figure)
+
+if __name__ == '__main__':
+    matplotlib.use('agg') # Use the AGG renderer to produce PNG output
+    if len(sys.argv) > 1:
+        bunch_parameter = sys.argv[1]
+        if bunch_parameter.isdigit():
+            bunch_list = list(range(1, int(bunch_parameter) + 1))
+        else:
+            try:
+                bunch_list = [int(value) for value in sys.argv[1].split(',')]
+            except:
+                bunch_list = list(range(1, int(get_bunch_count()) + 1))
+    else:
+        bunch_list = list(range(1, int(get_bunch_count()) + 1))
+    plot_all(bunch_list)

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -328,8 +328,8 @@ def plot_phase_spaces(axes, data, bunch_list, title=None, grid_size=100):
     z = data.T[4]
     pz = data.T[5]
     W = data.T[6]
-    xp = px/pz
-    yp = py/pz
+    xp = numpy.arctan(px/pz)
+    yp = numpy.arctan(py/pz)
     plot_phase_space(axes[0,0], x*1e3, xp*1e3, 'x (mm)', 'x` (mrad)', grid_size)
     plot_phase_space(axes[0,1], y*1e3, yp*1e3, 'y (mm)', 'y` (mrad)', grid_size)
     plot_phase_space(axes[1,1], x*1e3, y*1e3, 'x (mm)', 'y (mm)', grid_size)

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -111,7 +111,7 @@ def load_statistics_data(bunch_list, z_offset=None):
     ydata = []
     for bunch in bunch_list:
         x = load_data_from_file(f'fort.{bunch}024')
-        y = load_data_from_file(f'fort.{bunch}024')
+        y = load_data_from_file(f'fort.{bunch}025')
         if z_offset:
             x = shift_z(x, z_offset, 1)
             y = shift_z(y, z_offset, 1)

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -89,6 +89,23 @@ def check_bunch_list(bunch_list):
     invalid_bunches = [bunch for bunch in bunch_list if bunch > max_bunch]
     return valid_bunches, invalid_bunches
 
+def check_bunches(data, bunch_list):
+    """Check which bunches are empty, if any."""
+    empty = []
+    for idx, bunch in enumerate(data):
+        if len(bunch) == 0:
+            empty.append(bunch_list[idx])
+    not_empty = [bunch for bunch in bunch_list if bunch not in empty]
+    return not_empty, empty
+
+def get_non_empty(data):
+    """Return a dataset with empty bunches excluded."""
+    non_empty = []
+    for bunch in data:
+        if len(bunch) > 0:
+            non_empty.append(bunch)
+    return non_empty
+
 def read_input_file(filename):
     """Read input file and return list of input lines, excluding comments."""
     with open(filename, 'r') as f:
@@ -139,11 +156,15 @@ def load_phase_space_data(filenumber, bunch_list, z_offset=None):
 
 def shift_z(data, z_offset, z_col=1):
     """Shift all z values by the given offset."""
+    if len(data) == 0:
+        return data
     data[:,z_col] = data[:,z_col] - z_offset
     return data
 
 def calculate_energies(data, bunch):
     """Calculate the energies for per-bunch data and save as an extra column."""
+    if len(data) == 0:
+        return data
     gamma = numpy.sqrt(1 + numpy.square(data.T[1])
                          + numpy.square(data.T[3])
                          + numpy.square(data.T[5]))
@@ -190,7 +211,7 @@ def combine_bunch_values(data, bunch_list):
 
 def combine_phase_space_data(data):
     """Combine per-bunch phase space data into single array."""
-    return numpy.concatenate(data)
+    return numpy.concatenate(get_non_empty(data))
 
 def get_xdata(data, xaxis):
     """Return data for the given x-axis: time t (ns) or location z (mm)."""
@@ -319,6 +340,8 @@ def plot_bunch_count(axes, data, bunch_list, xaxis='t', title=None):
 
 def plot_phase_spaces(axes, data, bunch_list, title=None, grid_size=100):
     """Plot four phase spaces onto the given array of axes."""
+    if len(data) == 0:
+        raise ValueError('No data to plot.')
     if not title:
         title = 'Phase space for ' + bunch_text(bunch_list)
     axes[0,0].figure.suptitle(title)
@@ -372,13 +395,14 @@ def plot_bunch_energies(axes, data, bunch_list, title=None, bins=100):
     if not title:
         title = 'Energy spectra for ' + bunch_text(bunch_list)
     axes.figure.suptitle(title)
-    W = [bunch.T[6]/1e6 for bunch in data]
-    if len(bunch_list) > 1:
+    non_empty_bunches, _ = check_bunches(data, bunch_list)
+    W = [bunch.T[6]/1e6 for bunch in get_non_empty(data)]
+    if len(non_empty_bunches) > 1:
         axes.hist(numpy.concatenate(W), bins=bins, label='Total',
                   histtype='stepfilled', linewidth=1.0,
                   color='red', facecolor=(1,0,0,0.1), edgecolor=(1,0,0,1.0))
     axes.hist(W, bins=bins, histtype='stepfilled', alpha=0.5,
-              label=[f'Bunch {bunch}' for bunch in bunch_list])
+              label=[f'Bunch {bunch}' for bunch in non_empty_bunches])
     axes.set_xlabel('Energy (MeV)')
     axes.set_ylabel('Number of macroparticles')
     handles, labels = axes.get_legend_handles_labels()
@@ -412,141 +436,193 @@ def plot_all(bunch_list, z_offset=None):
     full_bunch_list = list(range(1, int(get_bunch_count()) + 1))
     bunch_list, invalid_bunches = check_bunch_list(bunch_list)
     if invalid_bunches:
-        print(f'Skipping invalid bunches: {invalid_bunches}')
+        print(f'! Skipping invalid bunches: {invalid_bunches}')
     print('Loading experimental data...')
     try:
         experimental_results = load_experimental_results()
     except FileNotFoundError as err:
-        print(f'Experimental results data file not found: {err}')
-        print('Continuing without experimental data.')
+        print(f'! Experimental results data file not found: {err}')
+        print( '! Continuing without experimental data.')
         experimental_results = None
     print('Loading statistical data...')
     try:
         xdata, ydata = load_statistics_data(bunch_list, z_offset)
     except FileNotFoundError as err:
-        print(f'Statistical data file not found: {err}')
-        print('Skipping statistical plots.')
+        print(f'! Statistical data file not found: {err}')
+        print( '! Skipping statistical plots.')
     else:
         combined_xdata = combine_bunch_values(xdata, bunch_list)
         combined_ydata = combine_bunch_values(ydata, bunch_list)
         print('Plotting beam size...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_beam_size(axes, xdata, bunch_list, combined_data=combined_xdata)
-        figure.savefig('beam-size')
+        try:
+            plot_beam_size(axes, xdata, bunch_list, combined_data=combined_xdata)
+        except Exception as err:
+            print(f'! Error plotting beam size: {err}')
+        else:
+            figure.savefig('beam-size')
         matplotlib.pyplot.close(figure)
         if experimental_results is not None:
             figure, axes = matplotlib.pyplot.subplots(dpi=300)
-            plot_beam_size(axes, xdata, bunch_list,
-                           combined_data=combined_xdata,
-                           experiment_data=experimental_results)
-            figure.savefig('beam-size-vs-experiment')
+            try:
+                plot_beam_size(axes, xdata, bunch_list,
+                               combined_data=combined_xdata,
+                               experiment_data=experimental_results)
+            except Exception as err:
+                print(f'! Error plotting beam size against experiment: {err}')
+            else:
+                figure.savefig('beam-size-vs-experiment')
             matplotlib.pyplot.close(figure)
         print('Plotting emittance...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_emittance(axes, xdata, ydata, bunch_list,
-                       combined_xdata=combined_xdata,
-                       combined_ydata=combined_ydata)
-        figure.savefig('emittance')
+        try:
+            plot_emittance(axes, xdata, ydata, bunch_list,
+                           combined_xdata=combined_xdata,
+                           combined_ydata=combined_ydata)
+        except Exception as err:
+            print(f'! Error plotting emittance: {err}')
+        else:
+            figure.savefig('emittance')
         matplotlib.pyplot.close(figure)
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_emittance_growth(axes, xdata, ydata, bunch_list,
-                              combined_xdata=combined_xdata,
-                              combined_ydata=combined_ydata)
-        figure.savefig('emittance-growth')
+        try:
+            plot_emittance_growth(axes, xdata, ydata, bunch_list,
+                                  combined_xdata=combined_xdata,
+                                  combined_ydata=combined_ydata)
+        except Exception as err:
+            print(f'! Error plotting emittance growth: {err}')
+        else:
+            figure.savefig('emittance-growth')
         matplotlib.pyplot.close(figure)
     print('Loading bunch count data...')
     try:
         data = load_bunch_count_data(z_offset)
     except FileNotFoundError as err:
-        print(f'Bunch count data file not found: {err}')
-        print('Skipping bunch count plot.')
+        print(f'! Bunch count data file not found: {err}')
+        print( '! Skipping bunch count plot.')
     else:
         print('Plotting bunch counts...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_bunch_count(axes, data, bunch_list)
-        figure.savefig('bunch-count')
+        try:
+            plot_bunch_count(axes, data, bunch_list)
+        except Exception as err:
+            print(f'! Error plotting bunch count: {err}')
+        else:
+            figure.savefig('bunch-count')
         matplotlib.pyplot.close(figure)
     print('Loading initial phase space data...')
     try:
         full_data = load_phase_space_data(40, full_bunch_list, z_offset)
     except FileNotFoundError as err:
-        print(f'Phase space data file not found: {err}')
-        print('Skipping initial phase space step.')
+        print(f'! Phase space data file not found: {err}')
+        print( '! Skipping initial phase space step.')
     except IndexError as err:
-        print(f'Error processing phase space data: {err}')
-        print('Skipping initial phase space step.')
+        print(f'! Error processing phase space data: {err}')
+        print( '! Skipping initial phase space step.')
     else:
         data = [full_data[bunch-1] for bunch in bunch_list]
         combined_data = combine_phase_space_data(data)
         print('Plotting initial phase space data...')
         figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
-        plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
-            title=f'Initial phase space for {bunch_text(bunch_list)}')
-        figure.savefig('phase-space-initial')
+        try:
+            plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
+                title=f'Initial phase space for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f'! Error plotting phase space data: {err}')
+        else:
+            figure.savefig('phase-space-initial')
         matplotlib.pyplot.close(figure)
         if len(full_bunch_list) > 1:
             for bunch in full_bunch_list:
                 figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                    title=f'Initial phase space for {bunch_text([bunch])}',
-                    grid_size=300)
-                figure.savefig(f'phase-space-initial-bunch{bunch}')
+                try:
+                    plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                        title=f'Initial phase space for {bunch_text([bunch])}',
+                        grid_size=300)
+                except Exception as err:
+                    print(f'! Error plotting bunch {bunch}: {err}')
+                else:
+                    figure.savefig(f'phase-space-initial-bunch{bunch}')
                 matplotlib.pyplot.close(figure)
         print('Plotting initial energy spectra...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_bunch_energies(axes, data, bunch_list, bins=300,
-            title=f'Initial energy spectra for {bunch_text(bunch_list)}')
-        figure.savefig('energies-initial')
+        try:
+            plot_bunch_energies(axes, data, bunch_list, bins=300,
+                title=f'Initial energy spectra for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f'! Error plotting energy spectra: {err}')
+        else:
+            figure.savefig('energies-initial')
         matplotlib.pyplot.close(figure)
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_total_energy(axes, combined_data, bunch_list, bins=300,
-            title=f'Initial total energy spectrum for {bunch_text(bunch_list)}')
-        figure.savefig('energy-initial')
+        try:
+            plot_total_energy(axes, combined_data, bunch_list, bins=300,
+                title=f'Initial total energy spectrum for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f'! Error plotting energy spectrum: {err}')
+        else:
+            figure.savefig('energy-initial')
         matplotlib.pyplot.close(figure)
     print('Loading final phase space data...')
     try:
         full_data = load_phase_space_data(50, full_bunch_list, z_offset)
     except FileNotFoundError as err:
-        print(f'Phase space data file not found: {err}')
-        print('Skipping final phase space step.')
+        print(f'! Phase space data file not found: {err}')
+        print( '! Skipping final phase space step.')
     except IndexError as err:
-        print(f'Error processing phase space data: {err}')
-        print('Skipping final phase space step.')
+        print(f'! Error processing phase space data: {err}')
+        print( '! Skipping final phase space step.')
     else:
         data = [full_data[bunch-1] for bunch in bunch_list]
         combined_data = combine_phase_space_data(data)
         print('Plotting final phase space data...')
         figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
-        plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
-            title=f'Final phase space for {bunch_text(bunch_list)}')
-        figure.savefig('phase-space-final')
+        try:
+            plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
+                title=f'Final phase space for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f'! Error plotting phase space data: {err}')
+        else:
+            figure.savefig('phase-space-final')
         matplotlib.pyplot.close(figure)
         if len(full_bunch_list) > 1:
             for bunch in full_bunch_list:
                 figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                    title=f'Final phase space for {bunch_text([bunch])}',
-                    grid_size=300)
-                figure.savefig(f'phase-space-final-bunch{bunch}')
+                try:
+                    plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                        title=f'Final phase space for {bunch_text([bunch])}',
+                        grid_size=300)
+                except Exception as err:
+                    print(f'! Error plotting bunch {bunch}: {err}')
+                else:
+                    figure.savefig(f'phase-space-final-bunch{bunch}')
                 matplotlib.pyplot.close(figure)
         print('Plotting final energy spectra...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_bunch_energies(axes, data,  bunch_list, bins=300,
-            title=f'Final energy spectra for {bunch_text(bunch_list)}')
-        figure.savefig('energies-final')
+        try:
+            plot_bunch_energies(axes, data,  bunch_list, bins=300,
+                title=f'Final energy spectra for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f'! Error plotting energy spectra: {err}')
+        else:
+            figure.savefig('energies-final')
         matplotlib.pyplot.close(figure)
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        plot_total_energy(axes, combined_data, bunch_list, bins=300,
-            title=f'Final total energy spectrum for {bunch_text(bunch_list)}')
-        figure.savefig('energy-final')
+        try:
+            plot_total_energy(axes, combined_data, bunch_list, bins=300,
+                title=f'Final total energy spectrum for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f'! Error plotting energy spectrum: {err}')
+        else:
+            figure.savefig('energy-final')
         matplotlib.pyplot.close(figure)
     print('Getting list of BPMs...')
     try:
         lattice = get_lattice()
         bpm_list = get_bpms(lattice, z_offset)
     except FileNotFoundError as err:
-        print(f'Input file not found: {err}')
-        print('Skipping BPM plot steps.')
+        print(f'! Input file not found: {err}')
+        print( '! Skipping BPM plot steps.')
     else:
         for location, filenumber in bpm_list:
             print(f'Loading BPM {filenumber} phase space data...')
@@ -554,43 +630,59 @@ def plot_all(bunch_list, z_offset=None):
                 full_data = load_phase_space_data(filenumber, full_bunch_list,
                                                   z_offset)
             except FileNotFoundError as err:
-                print(f'BPM data file not found: {err}')
-                print('Skipping this BPM plot step.')
+                print(f'! BPM data file not found: {err}')
+                print( '! Skipping this BPM plot step.')
             except IndexError as err:
-                print(f'Error processing phase space data: {err}')
-                print('Skipping this BPM plot step.')
+                print(f'! Error processing phase space data: {err}')
+                print( '! Skipping this BPM plot step.')
             else:
                 data = [full_data[bunch-1] for bunch in bunch_list]
                 combined_data = combine_phase_space_data(data)
                 print(f'Plotting BPM {filenumber} phase space data...')
                 figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                plot_phase_spaces(axes, combined_data, bunch_list,
-                                  title=(f'Phase space at z = {location} '
-                                         f'for {bunch_text(bunch_list)}'),
-                                  grid_size=300)
-                figure.savefig(f'phase-space-{filenumber}')
+                try:
+                    plot_phase_spaces(axes, combined_data, bunch_list,
+                                    title=(f'Phase space at z = {location} '
+                                            f'for {bunch_text(bunch_list)}'),
+                                    grid_size=300)
+                except Exception as err:
+                    print(f'! Error plotting phase space data: {err}')
+                else:
+                    figure.savefig(f'phase-space-{filenumber}')
                 matplotlib.pyplot.close(figure)
                 if len(full_bunch_list) > 1:
                     for bunch in full_bunch_list:
                         figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                        plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                                        title=(f'Phase space at z = {location} '
-                                                f'for {bunch_text([bunch])}'),
-                                        grid_size=300)
-                        figure.savefig(f'phase-space-{filenumber}-bunch{bunch}')
+                        try:
+                            plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                                title=(f'Phase space at z = {location} '
+                                       f'for {bunch_text([bunch])}'),
+                                grid_size=300)
+                        except Exception as err:
+                            print(f'! Error plotting bunch {bunch}: {err}')
+                        else:
+                            figure.savefig(f'phase-space-{filenumber}-bunch{bunch}')
                         matplotlib.pyplot.close(figure)
                 print(f'Plotting BPM {filenumber} energy spectra...')
                 figure, axes = matplotlib.pyplot.subplots(dpi=300)
-                plot_bunch_energies(axes, data, bunch_list, bins=300,
-                                    title=(f'Energy spectra at z = {location} '
-                                           f'for {bunch_text(bunch_list)}'))
-                figure.savefig(f'energies-{filenumber}')
+                try:
+                    plot_bunch_energies(axes, data, bunch_list, bins=300,
+                        title=(f'Energy spectra at z = {location} '
+                                f'for {bunch_text(bunch_list)}'))
+                except Exception as err:
+                    print(f'! Error plotting energy spectra: {err}')
+                else:
+                    figure.savefig(f'energies-{filenumber}')
                 matplotlib.pyplot.close(figure)
                 figure, axes = matplotlib.pyplot.subplots(dpi=300)
-                plot_total_energy(axes, combined_data, bunch_list, bins=300,
-                                  title=(f'Energy spectrum at z = {location} '
-                                         f'for {bunch_text(bunch_list)}'))
-                figure.savefig(f'energy-{filenumber}')
+                try:
+                    plot_total_energy(axes, combined_data, bunch_list, bins=300,
+                        title=(f'Energy spectrum at z = {location} '
+                                f'for {bunch_text(bunch_list)}'))
+                except Exception as err:
+                    print(f'! Error plotting energy spectrum: {err}')
+                else:
+                    figure.savefig(f'energy-{filenumber}')
                 matplotlib.pyplot.close(figure)
 
 if __name__ == '__main__':

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -28,7 +28,7 @@ def get_z_offset():
 def get_target_range():
     """Get the target energy range from the first input file."""
     input_lines = read_input_file(get_input_filename(1))
-    if len(input_lines[2].split()) > 9 and int(input_lines[2].split()[7]) == 1:
+    if len(input_lines[2].split()) >= 10:
         return [float(item) for item in input_lines[2].split()[8:10]]
 
 def get_lattice():

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -433,7 +433,6 @@ def add_plot_margins(axes, margin):
 
 def plot_all(bunch_list, z_offset=None):
     """Run and save all plots consecutively."""
-    full_bunch_list = list(range(1, int(get_bunch_count()) + 1))
     bunch_list, invalid_bunches = check_bunch_list(bunch_list)
     if invalid_bunches:
         print(f'! Skipping invalid bunches: {invalid_bunches}')
@@ -451,8 +450,13 @@ def plot_all(bunch_list, z_offset=None):
         print(f'! Statistical data file not found: {err}')
         print( '! Skipping statistical plots.')
     else:
-        combined_xdata = combine_bunch_values(xdata, bunch_list)
-        combined_ydata = combine_bunch_values(ydata, bunch_list)
+        try:
+            combined_xdata = combine_bunch_values(xdata, bunch_list)
+            combined_ydata = combine_bunch_values(ydata, bunch_list)
+        except Exception as err:
+            print(f'! Error calculating combined rms values: {err}')
+            combined_xdata = None
+            combined_ydata = None
         print('Plotting beam size...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
         try:
@@ -510,112 +514,24 @@ def plot_all(bunch_list, z_offset=None):
         else:
             figure.savefig('bunch-count')
         matplotlib.pyplot.close(figure)
-    print('Loading initial phase space data...')
+    print('Processing initial phase space data...')
     try:
-        full_data = load_phase_space_data(40, full_bunch_list, z_offset)
+        plot_phase_spaces_and_energies(40, 'initial', bunch_list, z_offset)
     except FileNotFoundError as err:
         print(f'! Phase space data file not found: {err}')
         print( '! Skipping initial phase space step.')
-    except IndexError as err:
+    except Exception as err:
         print(f'! Error processing phase space data: {err}')
         print( '! Skipping initial phase space step.')
-    else:
-        data = [full_data[bunch-1] for bunch in bunch_list]
-        combined_data = combine_phase_space_data(data)
-        print('Plotting initial phase space data...')
-        figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
-        try:
-            plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
-                title=f'Initial phase space for {bunch_text(bunch_list)}')
-        except Exception as err:
-            print(f'! Error plotting phase space data: {err}')
-        else:
-            figure.savefig('phase-space-initial')
-        matplotlib.pyplot.close(figure)
-        if len(full_bunch_list) > 1:
-            for bunch in full_bunch_list:
-                figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                try:
-                    plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                        title=f'Initial phase space for {bunch_text([bunch])}',
-                        grid_size=300)
-                except Exception as err:
-                    print(f'! Error plotting bunch {bunch}: {err}')
-                else:
-                    figure.savefig(f'phase-space-initial-bunch{bunch}')
-                matplotlib.pyplot.close(figure)
-        print('Plotting initial energy spectra...')
-        figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        try:
-            plot_bunch_energies(axes, data, bunch_list, bins=300,
-                title=f'Initial energy spectra for {bunch_text(bunch_list)}')
-        except Exception as err:
-            print(f'! Error plotting energy spectra: {err}')
-        else:
-            figure.savefig('energies-initial')
-        matplotlib.pyplot.close(figure)
-        figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        try:
-            plot_total_energy(axes, combined_data, bunch_list, bins=300,
-                title=f'Initial total energy spectrum for {bunch_text(bunch_list)}')
-        except Exception as err:
-            print(f'! Error plotting energy spectrum: {err}')
-        else:
-            figure.savefig('energy-initial')
-        matplotlib.pyplot.close(figure)
-    print('Loading final phase space data...')
+    print('Processing final phase space data...')
     try:
-        full_data = load_phase_space_data(50, full_bunch_list, z_offset)
+        plot_phase_spaces_and_energies(50, 'final', bunch_list, z_offset)
     except FileNotFoundError as err:
         print(f'! Phase space data file not found: {err}')
         print( '! Skipping final phase space step.')
-    except IndexError as err:
+    except Exception as err:
         print(f'! Error processing phase space data: {err}')
         print( '! Skipping final phase space step.')
-    else:
-        data = [full_data[bunch-1] for bunch in bunch_list]
-        combined_data = combine_phase_space_data(data)
-        print('Plotting final phase space data...')
-        figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
-        try:
-            plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
-                title=f'Final phase space for {bunch_text(bunch_list)}')
-        except Exception as err:
-            print(f'! Error plotting phase space data: {err}')
-        else:
-            figure.savefig('phase-space-final')
-        matplotlib.pyplot.close(figure)
-        if len(full_bunch_list) > 1:
-            for bunch in full_bunch_list:
-                figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                try:
-                    plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                        title=f'Final phase space for {bunch_text([bunch])}',
-                        grid_size=300)
-                except Exception as err:
-                    print(f'! Error plotting bunch {bunch}: {err}')
-                else:
-                    figure.savefig(f'phase-space-final-bunch{bunch}')
-                matplotlib.pyplot.close(figure)
-        print('Plotting final energy spectra...')
-        figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        try:
-            plot_bunch_energies(axes, data,  bunch_list, bins=300,
-                title=f'Final energy spectra for {bunch_text(bunch_list)}')
-        except Exception as err:
-            print(f'! Error plotting energy spectra: {err}')
-        else:
-            figure.savefig('energies-final')
-        matplotlib.pyplot.close(figure)
-        figure, axes = matplotlib.pyplot.subplots(dpi=300)
-        try:
-            plot_total_energy(axes, combined_data, bunch_list, bins=300,
-                title=f'Final total energy spectrum for {bunch_text(bunch_list)}')
-        except Exception as err:
-            print(f'! Error plotting energy spectrum: {err}')
-        else:
-            figure.savefig('energy-final')
-        matplotlib.pyplot.close(figure)
     print('Getting list of BPMs...')
     try:
         lattice = get_lattice()
@@ -625,65 +541,88 @@ def plot_all(bunch_list, z_offset=None):
         print( '! Skipping BPM plot steps.')
     else:
         for location, filenumber in bpm_list:
-            print(f'Loading BPM {filenumber} phase space data...')
+            print(f'Processing BPM {filenumber} phase space data...')
             try:
-                full_data = load_phase_space_data(filenumber, full_bunch_list,
-                                                  z_offset)
+                plot_phase_spaces_and_energies(
+                    filenumber, location, bunch_list, z_offset)
             except FileNotFoundError as err:
                 print(f'! BPM data file not found: {err}')
                 print( '! Skipping this BPM plot step.')
-            except IndexError as err:
+            except Exception as err:
                 print(f'! Error processing phase space data: {err}')
                 print( '! Skipping this BPM plot step.')
+
+def plot_phase_spaces_and_energies(filenumber, location, bunch_list, z_offset):
+    if filenumber == 40:
+        file_title = 'initial'
+        phase_title = 'Initial phase space'
+        energies_title = 'Initial energy spectra'
+        energy_title = 'Initial total energy spectrum'
+    elif filenumber == 50:
+        file_title = 'final'
+        phase_title = 'Final phase space'
+        energies_title = 'Final energy spectra'
+        energy_title = 'Final total energy spectrum'
+    else:
+        file_title = str(filenumber)
+        phase_title = f'Phase space at z = {location}'
+        energies_title = f'Energy spectra at z = {location}'
+        energy_title = f'Energy spectrum at z = {location}'
+    print(' - Loading phase space data...')
+    full_bunch_list = list(range(1, int(get_bunch_count()) + 1))
+    full_data = load_phase_space_data(filenumber, full_bunch_list, z_offset)
+    data = [full_data[bunch-1] for bunch in bunch_list]
+    try:
+        combined_data = combine_phase_space_data(data)
+    except Exception as err:
+        print(f' ! Error combining phase space data: {err}')
+        print( ' ! Skipping combined phase space plot steps.')
+        combined_data = None
+    else:
+        print(' - Plotting combined phase space...')
+        figure, axes = matplotlib.pyplot.subplots(nrows=2, ncols=2, dpi=300)
+        try:
+            plot_phase_spaces(axes, combined_data, bunch_list, grid_size=300,
+                title=f'{phase_title} for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f' ! Error plotting phase space data: {err}')
+        else:
+            figure.savefig(f'phase-space-{file_title}')
+        matplotlib.pyplot.close(figure)
+    if len(full_bunch_list) > 1:
+        print(' - Plotting individual bunch phase spaces...')
+        for bunch in full_bunch_list:
+            figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
+            try:
+                plot_phase_spaces(axes, full_data[bunch-1], [bunch],
+                    title=f'{phase_title} for {bunch_text([bunch])}',
+                    grid_size=300)
+            except Exception as err:
+                print(f' ! Error plotting bunch {bunch}: {err}')
             else:
-                data = [full_data[bunch-1] for bunch in bunch_list]
-                combined_data = combine_phase_space_data(data)
-                print(f'Plotting BPM {filenumber} phase space data...')
-                figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                try:
-                    plot_phase_spaces(axes, combined_data, bunch_list,
-                                    title=(f'Phase space at z = {location} '
-                                            f'for {bunch_text(bunch_list)}'),
-                                    grid_size=300)
-                except Exception as err:
-                    print(f'! Error plotting phase space data: {err}')
-                else:
-                    figure.savefig(f'phase-space-{filenumber}')
-                matplotlib.pyplot.close(figure)
-                if len(full_bunch_list) > 1:
-                    for bunch in full_bunch_list:
-                        figure, axes = matplotlib.pyplot.subplots(2, 2, dpi=300)
-                        try:
-                            plot_phase_spaces(axes, full_data[bunch-1], [bunch],
-                                title=(f'Phase space at z = {location} '
-                                       f'for {bunch_text([bunch])}'),
-                                grid_size=300)
-                        except Exception as err:
-                            print(f'! Error plotting bunch {bunch}: {err}')
-                        else:
-                            figure.savefig(f'phase-space-{filenumber}-bunch{bunch}')
-                        matplotlib.pyplot.close(figure)
-                print(f'Plotting BPM {filenumber} energy spectra...')
-                figure, axes = matplotlib.pyplot.subplots(dpi=300)
-                try:
-                    plot_bunch_energies(axes, data, bunch_list, bins=300,
-                        title=(f'Energy spectra at z = {location} '
-                                f'for {bunch_text(bunch_list)}'))
-                except Exception as err:
-                    print(f'! Error plotting energy spectra: {err}')
-                else:
-                    figure.savefig(f'energies-{filenumber}')
-                matplotlib.pyplot.close(figure)
-                figure, axes = matplotlib.pyplot.subplots(dpi=300)
-                try:
-                    plot_total_energy(axes, combined_data, bunch_list, bins=300,
-                        title=(f'Energy spectrum at z = {location} '
-                                f'for {bunch_text(bunch_list)}'))
-                except Exception as err:
-                    print(f'! Error plotting energy spectrum: {err}')
-                else:
-                    figure.savefig(f'energy-{filenumber}')
-                matplotlib.pyplot.close(figure)
+                figure.savefig(f'phase-space-{file_title}-bunch{bunch}')
+            matplotlib.pyplot.close(figure)
+    print(' - Plotting energy spectra...')
+    figure, axes = matplotlib.pyplot.subplots(dpi=300)
+    try:
+        plot_bunch_energies(axes, data, bunch_list, bins=300,
+            title=f'{energies_title} for {bunch_text(bunch_list)}')
+    except Exception as err:
+        print(f' ! Error plotting energy spectra: {err}')
+    else:
+        figure.savefig(f'energies-{file_title}')
+    matplotlib.pyplot.close(figure)
+    if combined_data is not None:
+        print(' - Plotting combined energy spectrum...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        try:
+            plot_total_energy(axes, combined_data, bunch_list, bins=300,
+                title=f'{energy_title} for {bunch_text(bunch_list)}')
+        except Exception as err:
+            print(f' ! Error plotting energy spectrum: {err}')
+        else:
+            figure.savefig(f'energy-{file_title}')
+        matplotlib.pyplot.close(figure)
 
 if __name__ == '__main__':
     matplotlib.use('agg') # Use the AGG renderer to produce PNG output

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -211,7 +211,11 @@ def combine_bunch_values(data, bunch_list):
 
 def combine_phase_space_data(data):
     """Combine per-bunch phase space data into single array."""
-    return numpy.concatenate(get_non_empty(data))
+    non_empty = get_non_empty(data)
+    if non_empty == []:
+        return non_empty
+    else:
+        return numpy.concatenate(non_empty)
 
 def get_xdata(data, xaxis):
     """Return data for the given x-axis: time t (ns) or location z (mm)."""

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -25,6 +25,12 @@ def get_z_offset():
     input_lines = read_input_file(get_input_filename(1))
     return float(input_lines[7].split()[5])
 
+def get_target_range():
+    """Get the target energy range from the first input file."""
+    input_lines = read_input_file(get_input_filename(1))
+    if len(input_lines[2].split()) > 9 and int(input_lines[2].split()[7]) == 1:
+        return [float(item) for item in input_lines[2].split()[8:10]]
+
 def get_lattice():
     """Get the lattice from the first input file as a list of lists."""
     input_lines = read_input_file(get_input_filename(1))
@@ -459,12 +465,13 @@ def select_by_energy(data, target_range):
     selected = selected[selected.T[6] <= max_energy]
     return selected
 
-def plot_all(bunch_list, target_range=None):
+def plot_all(bunch_list):
     """Run and save all plots consecutively."""
     bunch_list, invalid_bunches = check_bunch_list(bunch_list)
     if invalid_bunches:
         print(f'! Skipping invalid bunches: {invalid_bunches}')
     z_offset = get_z_offset()
+    target_range = get_target_range()
     print('Loading experimental data...')
     try:
         experimental_results = load_experimental_results()

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -257,18 +257,20 @@ def plot_beam_size(axes, data, bunch_list, xaxis='z', title=None,
         title = 'Beam sizes for ' + bunch_text(bunch_list)
     axes.figure.suptitle(title)
     axes.set_xlabel(get_xlabel(xaxis))
-    axes.set_ylabel('Beam size (mm)')
-    if combined_data is None:
-        combined_data = combine_bunch_values(data, bunch_list)
+    axes.set_ylabel('RMS beam size (mm)')
     if experiment_data is not None:
         plot_beam_size_experimental(axes, experiment_data)
-    for i in range(len(bunch_list)):
-        plot_beam_size_single(axes, data[i], xaxis, '--',
-                              label=f'Bunch {bunch_list[i]} rms')
-    if len(bunch_list) > 1:
+    if len(bunch_list) == 1:
+        plot_beam_size_single(axes, data[0], xaxis, 'r-', label=None)
+    else:
+        for i in range(len(bunch_list)):
+            plot_beam_size_single(axes, data[i], xaxis, '--',
+                                label=f'Bunch {bunch_list[i]}')
+        if combined_data is None:
+            combined_data = combine_bunch_values(data, bunch_list)
         plot_beam_size_single(axes, combined_data, xaxis, 'r-',
-                              label=f'Combined rms')
-    axes.legend(fontsize='x-small')
+                              label=f'Combined')
+        axes.legend(fontsize='x-small')
 
 def plot_beam_size_experimental(axes, data):
     """Plot experimental data points with error bars"""
@@ -293,17 +295,19 @@ def plot_emittance(axes, xdata, ydata, bunch_list, xaxis='t', title=None,
     axes.figure.suptitle(title)
     axes.set_xlabel(get_xlabel(xaxis))
     axes.set_ylabel('Normalised rms emittance (π mm mrad)')
-    for i in range(len(bunch_list)):
-        plot_emittance_single(axes, xdata[i], ydata[i], xaxis,
-                              '--', label=f'Bunch {bunch_list[i]}')
-    if len(bunch_list) > 1:
+    if len(bunch_list) == 1:
+        plot_emittance_single(axes, xdata[0], ydata[0], xaxis, 'r-', label=None)
+    else:
+        for i in range(len(bunch_list)):
+            plot_emittance_single(axes, xdata[i], ydata[i], xaxis,
+                                  '--', label=f'Bunch {bunch_list[i]}')
         if combined_xdata is None:
             combined_xdata = combine_bunch_values(xdata, bunch_list)
         if combined_ydata is None:
             combined_ydata = combine_bunch_values(ydata, bunch_list)
         plot_emittance_single(axes, combined_xdata, combined_ydata, xaxis,
                               'r-', label='Combined')
-    axes.legend(fontsize='x-small')
+        axes.legend(fontsize='x-small')
 
 def plot_emittance_single(axes, xdata, ydata, xaxis, fmt, label):
     """Plot the average x and y emittance onto the given axes."""
@@ -319,10 +323,13 @@ def plot_emittance_growth(axes, xdata, ydata, bunch_list, xaxis='t', title=None,
     axes.figure.suptitle(title)
     axes.set_xlabel(get_xlabel(xaxis))
     axes.set_ylabel('Average emittance growth in x and y (relative)')
-    for i in range(len(bunch_list)):
-        plot_emittance_growth_single(axes, xdata[i], ydata[i], xaxis,
-                                     '--', label=f'Bunch {bunch_list[i]}')
-    if len(bunch_list) > 1:
+    if len(bunch_list) == 1:
+        plot_emittance_growth_single(axes, xdata[0], ydata[0], xaxis,
+                                     'r-', label=None)
+    else:
+        for i in range(len(bunch_list)):
+            plot_emittance_growth_single(axes, xdata[i], ydata[i], xaxis,
+                                        '--', label=f'Bunch {bunch_list[i]}')
         if combined_xdata is None:
             combined_xdata = combine_bunch_values(xdata, bunch_list)
         if combined_ydata is None:
@@ -351,7 +358,8 @@ def plot_bunch_count(axes, data, bunch_list, xaxis='t', title=None):
     axes.set_xlim(left=0.0)
     axes.set_xlabel(xlabel)
     axes.set_ylabel('Number of macroparticles')
-    axes.legend()
+    if len(bunch_list) > 1:
+        axes.legend()
 
 def plot_phase_spaces(axes, data, bunch_list, title=None, grid_size=100):
     """Plot four phase spaces onto the given array of axes."""
@@ -412,18 +420,20 @@ def plot_bunch_energies(axes, data, bunch_list, title=None, bins=100):
     axes.figure.suptitle(title)
     non_empty_bunches, _ = check_bunches(data, bunch_list)
     W = [bunch.T[6]/1e6 for bunch in get_non_empty(data)]
-    if len(non_empty_bunches) > 1:
+    if len(non_empty_bunches) == 1:
+        axes.hist(W, bins=bins, histtype='stepfilled', linewidth=1.0, label=None)
+    else:
         axes.hist(numpy.concatenate(W), bins=bins, label='Total',
                   histtype='stepfilled', linewidth=1.0,
                   color='red', facecolor=(1,0,0,0.1), edgecolor=(1,0,0,1.0))
-    axes.hist(W, bins=bins, histtype='stepfilled', alpha=0.5,
-              label=[f'Bunch {bunch}' for bunch in non_empty_bunches])
+        axes.hist(W, bins=bins, histtype='stepfilled', alpha=0.5,
+                  label=[f'Bunch {bunch}' for bunch in non_empty_bunches])
+        handles, labels = axes.get_legend_handles_labels()
+        handles.reverse()
+        labels.reverse()
+        axes.legend(handles, labels, loc='upper right')
     axes.set_xlabel('Energy (MeV)')
     axes.set_ylabel('Number of macroparticles')
-    handles, labels = axes.get_legend_handles_labels()
-    handles.reverse()
-    labels.reverse()
-    axes.legend(handles, labels, loc='upper right')
 
 def plot_total_energy(axes, combined_data, bunch_list, title=None, bins=100,
                       target_range=None):

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -17,13 +17,18 @@ def get_input_filename(bunch):
 
 def get_bunch_count():
     """Get the number of bunches from the first input file."""
-    input = read_input_file(get_input_filename(1))
-    return int(input[1].split()[2])
+    input_lines = read_input_file(get_input_filename(1))
+    return int(input_lines[1].split()[2])
+
+def get_z_offset():
+    """Get the initial z-offset from the first input file."""
+    input_lines = read_input_file(get_input_filename(1))
+    return float(input_lines[7].split()[5])
 
 def get_lattice():
     """Get the lattice from the first input file as a list of lists."""
-    input = read_input_file(get_input_filename(1))
-    return [line.split() for line in input[9:]]
+    input_lines = read_input_file(get_input_filename(1))
+    return [line.split() for line in input_lines[9:]]
 
 def get_bpms(lattice, z_offset=None):
     """Get the location and file number of all BPMs as a list of tuples."""
@@ -53,13 +58,13 @@ def get_bunch_counts(bunch_list):
 
 def get_particle_count(filename):
     """Get the macroparticle count from a given input file."""
-    input = read_input_file(filename)
-    return int(input[2].split()[1])
+    input_lines = read_input_file(filename)
+    return int(input_lines[2].split()[1])
 
 def get_mass(filename):
     """Get the particle mass from a given input file."""
-    input = read_input_file(filename)
-    return float(input[8].split()[2])
+    input_lines = read_input_file(filename)
+    return float(input_lines[8].split()[2])
 
 def is_mass_matched(bunch_list):
     """Check whether the particle mass values are the same for given bunches."""
@@ -435,11 +440,12 @@ def add_plot_margins(axes, margin):
     axes.set_xlim(xmin - xmargin, xmax + xmargin)
     axes.set_ylim(ymin - ymargin, ymax + ymargin)
 
-def plot_all(bunch_list, z_offset=None):
+def plot_all(bunch_list):
     """Run and save all plots consecutively."""
     bunch_list, invalid_bunches = check_bunch_list(bunch_list)
     if invalid_bunches:
         print(f'! Skipping invalid bunches: {invalid_bunches}')
+    z_offset = get_z_offset()
     print('Loading experimental data...')
     try:
         experimental_results = load_experimental_results()
@@ -641,12 +647,4 @@ if __name__ == '__main__':
                 bunch_list = list(range(1, int(get_bunch_count()) + 1))
     else:
         bunch_list = list(range(1, int(get_bunch_count()) + 1))
-    if len(sys.argv) > 2:
-        z_offset = sys.argv[2]
-        try:
-            z_offset = float(z_offset)
-        except:
-            z_offset = None
-    else:
-        z_offset = None
-    plot_all(bunch_list, z_offset)
+    plot_all(bunch_list)

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -512,6 +512,15 @@ def plot_all(bunch_list):
         else:
             figure.savefig('beam-size')
         matplotlib.pyplot.close(figure)
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        try:
+            plot_beam_size(axes, xdata, bunch_list, combined_data=combined_xdata,
+                           xaxis='t')
+        except Exception as err:
+            print(f'! Error plotting beam size vs t: {err}')
+        else:
+            figure.savefig('beam-size-t')
+        matplotlib.pyplot.close(figure)
         if experimental_results is not None:
             figure, axes = matplotlib.pyplot.subplots(dpi=300)
             try:

--- a/GUI/src/MultiBunchPlot.py
+++ b/GUI/src/MultiBunchPlot.py
@@ -287,6 +287,29 @@ def plot_beam_size_single(axes, data, xaxis, fmt, label):
     rms = data.T[3]*1.0e3
     axes.plot(x, rms, fmt, linewidth=1, label=label)
 
+def plot_z(axes, data, bunch_list, title=None, combined_data=None):
+    """Create a plot of z vs t per bunch."""
+    if not title:
+        title = 'Bunch motion for ' + bunch_text(bunch_list)
+    axes.figure.suptitle(title)
+    axes.set_xlabel(get_xlabel('t'))
+    axes.set_ylabel(get_xlabel('z'))
+    if len(bunch_list) == 1:
+        plot_z_single(axes, data[0], 'r-', label=None)
+    else:
+        for i in range(len(bunch_list)):
+            plot_z_single(axes, data[i], '--', label=f'Bunch {bunch_list[i]}')
+        if combined_data is None:
+            combined_data = combine_bunch_values(data, bunch_list)
+        plot_z_single(axes, combined_data, 'r-', label=f'Combined')
+        axes.legend(fontsize='x-small')
+
+def plot_z_single(axes, data, fmt, label):
+    """Plot the average z-position against time."""
+    t = get_xdata(data, 't')
+    z = get_xdata(data, 'z')
+    axes.plot(t, z, fmt, linewidth=1, label=label)
+
 def plot_emittance(axes, xdata, ydata, bunch_list, xaxis='t', title=None,
                    combined_xdata=None, combined_ydata=None):
     """Create a plot of average x and y emittance per bunch."""
@@ -503,6 +526,15 @@ def plot_all(bunch_list):
             print(f'! Error calculating combined rms values: {err}')
             combined_xdata = None
             combined_ydata = None
+        print('Plotting bunch motion...')
+        figure, axes = matplotlib.pyplot.subplots(dpi=300)
+        try:
+            plot_z(axes, xdata, bunch_list, combined_data=combined_xdata)
+        except Exception as err:
+            print(f'! Error plotting bunch motion: {err}')
+        else:
+            figure.savefig('bunch-motion')
+        matplotlib.pyplot.close(figure)
         print('Plotting beam size...')
         figure, axes = matplotlib.pyplot.subplots(dpi=300)
         try:

--- a/GUI/src/ParticlePlot.py
+++ b/GUI/src/ParticlePlot.py
@@ -30,20 +30,20 @@ class ParticleBaseFrame(tk.Frame):
                                'Py (MC)'      :3,
                                'Z (deg)'      :4,
                                'Pz (MC)'      :5}
-    
+
     ParticleDirec = {'X'       :0,
                      'Px'      :1,
                      'Y'       :2,
                      'Py'      :3,
                      'Z'       :4,
                      'Pz'      :5}
-    
+
     sciFormatter = FormatStrFormatter('%2.1E')
     sciMaxLimit  = 99999 *2
     sciMinLimit  = 0.0001*2
     DefaultUnit_T = ['mm','MC','mm','MC','mm','MC']
     DefaultUnit_Z = ['mm','MC','mm','MC','deg','MC']
-    
+
     data = np.array([])
     def __init__(self, parent, PlotFileName,scaling,TorZ):
         tk.Frame.__init__(self, parent)
@@ -52,9 +52,9 @@ class ParticleBaseFrame(tk.Frame):
         except:
             print( "ERROR! Can't open file '" + PlotFileName + "'")
             return
-        
+
         self.data = np.transpose(self.data)
-        
+
         if TorZ == 'ImpactZ':
             print("The position of X and Y had been multiplied by omege/c to meet the unit Conversion from ImpactZ")
             try:
@@ -77,34 +77,34 @@ class ParticleBaseFrame(tk.Frame):
                     print( "Warning: Can't read the column " + str(i)+" @ '" + PlotFileName + "'")
         else:
             print("Warning: cannot recognize T or Z.")
-            
+
         self.frame_PlotParticleControl = tk.Frame(self)
         self.frame_PlotParticleControl.pack()
-        
+
         self.label_scalingX        = tk.Label(self.frame_PlotParticleControl, text="ScalingX:")
         self.label_scalingX.pack(side='left')
         self.scalingX       = tk.Entry(self.frame_PlotParticleControl,  width=7)
         self.scalingX.insert(0, '1.0')
         self.scalingX.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.label_scalingY        = tk.Label(self.frame_PlotParticleControl, text="ScalingY:")
         self.label_scalingY.pack(side='left')
         self.scalingY       = tk.Entry(self.frame_PlotParticleControl,  width=7)
         self.scalingY.insert(0, '1.0')
         self.scalingY.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.label_unitX        = tk.Label(self.frame_PlotParticleControl, text="UnitAxi1:")
         self.label_unitX.pack(side='left')
         self.unitX       = tk.Entry(self.frame_PlotParticleControl,  width=6)
         self.unitX.insert(0, 'mm')
         self.unitX.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.label_unitY        = tk.Label(self.frame_PlotParticleControl, text="UnitAxi2:")
         self.label_unitY.pack(side='left')
         self.unitY       = tk.Entry(self.frame_PlotParticleControl,  width=6)
         self.unitY.insert(0, 'MC')
         self.unitY.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.label_x        = tk.Label(self.frame_PlotParticleControl, text="Axi1:")
         self.label_x.pack(side='left')
 
@@ -114,7 +114,7 @@ class ParticleBaseFrame(tk.Frame):
                                        values=['X', 'Px', 'Y', 'Py','Z','Pz'])
         #                               values=['X (mm)', 'Px (MC)', 'Y (mm)', 'Py (MC)','Z (deg)','Pz (MC)'])
         self.ppc1.pack(fill = 'both',expand =1,side = 'left')
-        
+
         self.label_y        = tk.Label(self.frame_PlotParticleControl, text="Axi2:")
         self.label_y.pack(side='left')
         self.ppc2Value  = tk.StringVar(self.frame_PlotParticleControl,'Px')
@@ -123,7 +123,7 @@ class ParticleBaseFrame(tk.Frame):
                                        values=['X', 'Px', 'Y', 'Py','Z','Pz'])
         #                               values=['X (mm)', 'Px (MC)', 'Y (mm)', 'Py (MC)','Z (deg)','Pz (MC)'])
         self.ppc2.pack(fill = 'both',expand =1,side = 'left')
-        
+
         LARGE_FONT= ("Verdana", 12)
         self.button_ppc=tk.Button(self.frame_PlotParticleControl)
         self.button_ppc["text"]         = "Plot"
@@ -132,28 +132,28 @@ class ParticleBaseFrame(tk.Frame):
         self.button_ppc["font"]         = LARGE_FONT
         self.button_ppc["command"]      = self.plot
         self.button_ppc.pack(fill = 'both',expand =1,side = 'right')
-        
+
         self.ppc1Value.trace('w',lambda a,b,c,direc='X': self.update(direc))
         self.ppc2Value.trace('w',lambda a,b,c,direc='Y': self.update(direc))
 
         x   = self.ParticleDirec[self.ppc1.get()]
         y   = self.ParticleDirec[self.ppc2.get()]
-        
+
         self.fig = Figure(figsize=(7,6), dpi=100)
         self.subfig = self.fig.add_subplot(111)
         self.subfig.scatter(self.data[x],self.data[y],s=1)
-        
+
         box = self.subfig.get_position()
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
-        
+
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-        
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
     def update(self,direction):
         if direction == 'X':
             self.scalingX.delete(0, 'end')
@@ -190,19 +190,19 @@ class ParticleFrame(ParticleBaseFrame):
     def __init__(self, parent, PlotFileName,scaling,TorZ):
         ParticleBaseFrame.__init__(self, parent,PlotFileName,scaling,TorZ)
         self.plot()
-        
+
     def plot(self):
         xData   = self.data[self.ParticleDirec[self.ppc1.get()]] * float(self.scalingX.get())
         yData   = self.data[self.ParticleDirec[self.ppc2.get()]] * float(self.scalingY.get())
-        
+
         #self.fig.clf()
         #self.subfig = self.fig.add_subplot(111)
         self.subfig.cla()
-        
+
         self.subfig.scatter(xData,yData,s=1)
         #self.subfig.relim()
         self.subfig.autoscale()
-        
+
         xMax = np.max(xData)
         xMin = np.min(xData)
         yMax = np.max(yData)
@@ -211,14 +211,14 @@ class ParticleFrame(ParticleBaseFrame):
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
         if (yMax-yMin)>self.sciMaxLimit or (yMax-yMin)<self.sciMinLimit:
             self.subfig.yaxis.set_major_formatter(self.sciFormatter)
-        
+
         self.subfig.set_xlabel(self.ppc1.get()+' ('+self.unitX.get()+')')
         self.subfig.set_ylabel(self.ppc2.get()+' ('+self.unitY.get()+')')
         self.canvas.draw()
-        
+
     def quit(self):
         self.destroy()
-        
+
 
 
 class ParticleDensityFrame_weight1D(ParticleBaseFrame):
@@ -226,30 +226,30 @@ class ParticleDensityFrame_weight1D(ParticleBaseFrame):
         ParticleBaseFrame.__init__(self, parent,PlotFileName,scaling,TorZ)
         self.ppc2.pack_forget()
         self.label_y.pack_forget()
-        
+
         self.unitY.pack_forget()
         self.label_unitY.pack_forget()
-        
+
         self.label_scalingY.pack_forget()
         self.scalingY.pack_forget()
-        
+
         self.plot()
-        
+
     def plot(self):
         xData   = self.data[self.ParticleDirec[self.ppc1.get()]] * float(self.scalingX.get())
-        
+
         self.subfig.cla()
-        
+
         nx = 200
-        
+
         xMax = np.max(xData)
         xMin = np.min(xData)
-        
+
         hx = (xMax-xMin)/(nx-1)
-        
+
         count = np.zeros(nx)
         tickx  = [xMin + i * (xMax-xMin)/(nx-1) for i in range(nx)]
-        
+
         for i in range(0,len(xData)):
             ix = int((xData[i] - xMin)/hx)
             if ix<0:
@@ -258,33 +258,33 @@ class ParticleDensityFrame_weight1D(ParticleBaseFrame):
             if ix>=nx-1:
                 ix=nx-2
             ab = (xData[i] - (xMin+ix*hx))/hx
-            
+
             count[ix  ] += 1.0-ab
             count[ix+1] += ab
             pass
         count = count/np.max(count)
         self.subfig.fill_between(tickx,0,count)#,extent=(xMin,xMax,yMin,yMax))#plt.cm.ocean)
         #plt.colorbar()
-        
+
         xMax = np.max(xData)
         xMin = np.min(xData)
         if (xMax-xMin)>self.sciMaxLimit or (xMax-xMin)<self.sciMinLimit:
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
-        
+
         self.subfig.set_xlabel(self.ppc1.get()+' ('+self.unitX.get()+')')
         self.subfig.set_ylabel('Density')
 
-        self.canvas.draw()        
+        self.canvas.draw()
 class ParticleDensityFrame_weight2D(ParticleBaseFrame):
     def __init__(self, parent, PlotFileName,scaling,TorZ):
         ParticleBaseFrame.__init__(self, parent,PlotFileName,scaling,TorZ)
-        
+
         self.label_gridSizeX        = tk.Label(self.frame_PlotParticleControl, text="GridSize:")
         self.label_gridSizeX.pack(side='left')
         self.gridSizeX       = tk.Entry(self.frame_PlotParticleControl,  width=5)
         self.gridSizeX.insert(0, '200')
         self.gridSizeX.pack(fill = 'both',expand =1,side = 'left')
-        
+
         '''
         self.label_gridSizeY        = tk.Label(self.frame_PlotParticleControl, text="GridSizeY:")
         self.label_gridSizeY.pack(side='left')
@@ -292,7 +292,7 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
         self.gridSizeY.insert(0, '100')
         self.gridSizeY.pack(fill = 'both',expand =1,side = 'left')
         '''
-        
+
         '''
         self.button_ppc["text"] = "ContourPlot"
         LARGE_FONT= ("Verdana", 12)
@@ -304,15 +304,15 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
         self.button_ppc1["command"] = lambda:self.plot(flag = 'gridDensity')
         self.button_ppc1.pack(fill = 'both',expand =1,side = 'right')
         '''
-        
+
         self.plot()
-        
+
     def plot(self,flag='ContourPlot'):
         xData   = self.data[self.ParticleDirec[self.ppc1.get()]] * float(self.scalingX.get())
         yData   = self.data[self.ParticleDirec[self.ppc2.get()]] * float(self.scalingY.get())
-        
+
         self.subfig.cla()
-        
+
         try:
             nx=int(self.gridSizeX.get())
             ny=int(self.gridSizeX.get())
@@ -328,12 +328,12 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
         yMax = np.max(yData)
         xMin = np.min(xData)
         yMin = np.min(yData)
-        
+
         hx = (xMax-xMin)/(nx-1)
         hy = (yMax-yMin)/(ny-1)
-        
+
         count = np.zeros([ny,nx])
-        
+
         for i in range(0,len(xData)):
             if xData[i] < xMin or xData[i] > xMax:
                 continue
@@ -353,14 +353,14 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
                 iy=ny-2
             ab = (xData[i] - (xMin+ix*hx))/hx
             cd = (yData[i] - (yMin+iy*hy))/hy
-            
+
             #iy=ny-iy-2
             count[iy  ,ix  ] += (1.0-ab) * (1.0-cd)
-            count[iy+1,ix  ] += (    ab) * (1.0-cd) 
-            count[iy  ,ix+1] += (1.0-ab) * (    cd) 
-            count[iy+1,ix+1] += (    ab) * (    cd) 
+            count[iy+1,ix  ] += (    ab) * (1.0-cd)
+            count[iy  ,ix+1] += (1.0-ab) * (    cd)
+            count[iy+1,ix+1] += (    ab) * (    cd)
             pass
-        
+
         count[count == 0.0] = -0.0000001
         tmap = plt.cm.jet
         tmap.set_under('white',0.)
@@ -371,10 +371,10 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
             #count = scipy.ndimage.zoom(count, 3)
             self.msh = self.subfig.contourf(x, y, count,level=12,interpolation='gaussian',cmap =tmap , vmin=0.0001)
         else:
-            self.msh = self.subfig.imshow(count, origin = "lower", interpolation='bilinear', 
+            self.msh = self.subfig.imshow(count, origin = "lower", interpolation='bilinear',
                                       cmap=tmap,vmin=0.0000001,
                                       extent=(xMin,xMax,yMin,yMax),aspect="auto")#plt.cm.ocean)
-        
+
         if (xMax-xMin)>self.sciMaxLimit or (xMax-xMin)<self.sciMinLimit:
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
         if (yMax-yMin)>self.sciMaxLimit or (yMax-yMin)<self.sciMinLimit:
@@ -385,7 +385,7 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
         labelx = ['{:2.2e}'.format(xMin+i*(xMax-xMin)/(ntick-1)) for i in range(ntick)]
         self.subfig.set_xticks(tickx)
         self.subfig.set_xticklabels(labelx)
-        
+
         ticky  = [i*(ny-0)/(ntick-1) for i in range(ntick)]
         labely = ['{:2.2e}'.format(yMin+i*(yMax-yMin)/(ntick-1)) for i in range(ntick)]
         self.subfig.set_yticks(ticky)
@@ -395,20 +395,20 @@ class ParticleDensityFrame_weight2D(ParticleBaseFrame):
         self.subfig.set_ylabel(self.ppc2.get()+' ('+self.unitY.get()+')')
 
         self.canvas.draw()
-        
+
 class ParticleDensityFrame1D(ParticleBaseFrame):
     def __init__(self, parent, PlotFileName,scaling,TorZ):
         ParticleBaseFrame.__init__(self, parent,PlotFileName,scaling,TorZ)
         self.ppc2.pack_forget()
         self.label_y.pack_forget()
-        
+
         self.label_scalingY.pack_forget()
         self.scalingY.pack_forget()
         self.plot()
-        
+
     def plot(self):
         xData   = self.data[self.ParticleDirec[self.ppc1.get()]] * float(self.scalingX.get())
-        
+
         self.subfig.cla()
         self.subfig.hist(xData,bins=100)
 
@@ -416,21 +416,21 @@ class ParticleDensityFrame1D(ParticleBaseFrame):
         xMin = np.min(xData)
         if (xMax-xMin)>self.sciMaxLimit or (xMax-xMin)<self.sciMinLimit:
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
-        
+
         self.subfig.set_xlabel(self.ppc1.get()+' ('+self.unitX.get()+')')
         self.subfig.set_ylabel('Density')
 
         self.canvas.draw()
-        
+
 class ParticleDensityFrame2D(ParticleBaseFrame):
-    def __init__(self, parent,ifile,scaling,TorZ):    
+    def __init__(self, parent,ifile,scaling,TorZ):
         ParticleBaseFrame.__init__(self, parent, ifile, scaling,TorZ)
         self.plot()
-        
+
     def plot(self):
         xData   = self.data[self.ParticleDirec[self.ppc1.get()]] * float(self.scalingX.get())
         yData   = self.data[self.ParticleDirec[self.ppc2.get()]] * float(self.scalingY.get())
-        
+
         self.subfig.cla()
         self.subfig.hist2d(xData,yData,(100, 100),cmap = 'jet')
 
@@ -442,30 +442,30 @@ class ParticleDensityFrame2D(ParticleBaseFrame):
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
         if (yMax-yMin)>self.sciMaxLimit or (yMax-yMin)<self.sciMinLimit:
             self.subfig.yaxis.set_major_formatter(self.sciFormatter)
-        
+
         self.subfig.set_xlabel(self.ppc1.get()+' ('+self.unitX.get()+')')
         self.subfig.set_ylabel(self.ppc2.get()+' ('+self.unitY.get()+')')
 
         self.canvas.draw()
-        
+
 class ParticleDensityFrame2D_slow(ParticleBaseFrame):
     def __init__(self, parent, PlotFileName,scaling,TorZ):
         ParticleBaseFrame.__init__(self, parent,PlotFileName,scaling,TorZ)
         self.plot()
-        
+
     def plot(self):
         xData   = self.data[self.ParticleDirec[self.ppc1.get()]] * float(self.scalingX.get())
         yData   = self.data[self.ParticleDirec[self.ppc2.get()]] * float(self.scalingY.get())
-        
-        self.subfig.cla()       
+
+        self.subfig.cla()
         '''Calculate the point density'''
         xy = np.vstack([xData,yData])
         z = gaussian_kde(xy)(xy)
-    
+
         '''Sort the points by density, so that the densest points are plotted last'''
         idx = z.argsort()
-        x, y, z = xData[idx], yData[idx], z[idx]        
-        
+        x, y, z = xData[idx], yData[idx], z[idx]
+
         self.subfig.scatter(x, y, c=z, s=10, edgecolor='')
 
         xMax = np.max(xData)
@@ -476,7 +476,7 @@ class ParticleDensityFrame2D_slow(ParticleBaseFrame):
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
         if (yMax-yMin)>self.sciMaxLimit or (yMax-yMin)<self.sciMinLimit:
             self.subfig.yaxis.set_major_formatter(self.sciFormatter)
-        
+
         self.subfig.set_xlabel(self.ppc1.get()+' ('+self.unitX.get()+')')
         self.subfig.set_ylabel(self.ppc2.get()+' ('+self.unitY.get()+')')
 

--- a/GUI/src/ParticlePlot.py
+++ b/GUI/src/ParticlePlot.py
@@ -147,7 +147,7 @@ class ParticleBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
         
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/ParticlePlot.py
+++ b/GUI/src/ParticlePlot.py
@@ -5,7 +5,7 @@ import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 from scipy.stats import gaussian_kde
@@ -150,7 +150,7 @@ class ParticleBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/PreProcessing.py
+++ b/GUI/src/PreProcessing.py
@@ -4,9 +4,9 @@ from glob import glob
 from shutil import copyfile
 #
 #--- (c) Copyright, 2014 by the Regents of the University of California.
-#This PreProcessing.py is based on the PhaseOpt.py beta v. 1.1: 
+#This PreProcessing.py is based on the PhaseOpt.py beta v. 1.1:
 #Authors: Zhicong Liu, T. Wilson,  and J. Qiang.
-#Description: 
+#Description:
 #             Find the RF driven phase used in the ImpactT.in given the
 #             design phase initially specified in the ImpactT.in.
 #             The initial ImpactT.in is copied into file ImpactT_backup.in.
@@ -44,7 +44,7 @@ tol = 0.0001
 # max number of iterations in Brent's Method before quitting
 it_max = 20
 
-    
+
 def process(parent):
     # remove previous data files
     files = glob(os.path.join('.' + "/ang_*"))
@@ -52,10 +52,10 @@ def process(parent):
     files += glob(os.path.join('.' + "/data_*"))
     for f in files:
         os.remove(f)
-    
+
     # create backup of ImpactT.in
     copyfile('ImpactT.in','ImpactT_backup.in')
-    
+
     # from row_start to row_end, optimize beam elements one at a time
     row_start = 14
     row_end = len(open('ImpactT.in').readlines())
@@ -67,7 +67,7 @@ def process(parent):
     length = -1
     freq = -1
     prediction = -1
-    
+
     global angle_in
     global angle_end
     global delv
@@ -100,7 +100,7 @@ def process(parent):
     for i in range(row_start, row_end):
         # set angle_in and angle_end back to default values stored in angle_inVal and angle_endVal
         # This is reset for every row, just in case our prediction is bad (cannot find a max within +/- 20 degrees
-        # of the prediction), so we are forced to scan the entire default range to find a max. 
+        # of the prediction), so we are forced to scan the entire default range to find a max.
         angle_in  = angle_inVal
         angle_end = angle_endVal
 
@@ -108,7 +108,7 @@ def process(parent):
         file = open('ImpactT.in', 'r')
         lines = file.readlines()
         file.close()
-        
+
         print(lines[i].split(),col_el,col_freq)
 
 
@@ -135,23 +135,23 @@ def process(parent):
                     # makes sure that we only insert one set of -3 and -99 lines
                     # more than one can be inserted if we have duplicate beam elements
                     inserted = True
-                    
+
                     # set position parameters for -3 and -99 line
                     length_str = (lines[i].split())[0]
                     prev_length = length
                     length = float(length_str.replace('d','E'))
-                    
+
                     zedge_str = lines[i].split()[4]
                     prev_zedge = zedge
                     zedge = float(zedge_str.replace('d','E'))
-                    
+
                     cav_end = zedge + length
                     # create -3 and -99 lines
                     tmp3line = '0 0 80 -3 '+str(cav_end)+' '+str(cav_end)+' '+str(cav_end)+' / \n'
                     tmp99line = '0 0 0 -99 '+str(cav_end)+' '+str(cav_end)+' '+str(cav_end)+' / \n'
                     x = x+line
                     x = x+tmp3line+tmp99line
-                    
+
                     print(zedge,length,cav_end)
 
                 else:
@@ -166,10 +166,10 @@ def process(parent):
             # predict next phase angle if RstartFlag = 1 (if this isn't the first beam element)
             if int((lines[row_restart].split())[1]) == 1:
                prediction = predict(zedge, prev_zedge, max_ang, prev_freq, prev_length)
-            
+
             # determine phase angle for which energy is a maximum
             max_ang = findMax(i, cav_end, prediction)
-            
+
             # write user specified angle relative to zero phase (max angle) into ImpactT.in
             file = open('ImpactT.in','r')
             lines = file.readlines()
@@ -186,7 +186,7 @@ def process(parent):
             file = open('ImpactT.in','w')
             file.writelines(lines)
             file.close()
-            
+
             file = open('ImpactT.in','r')
             lines = file.readlines()
             file.close()
@@ -253,7 +253,7 @@ def process(parent):
             # We will need this data for the next beam element because we restart simulation right after
             # current beam element.
             copyfile('fort.80','temp_fort.80')
- 
+
 
    # After looping over all lines in ImpactT.in, we're done.
    # Set Rstartflag back to 0 for next run.
@@ -292,18 +292,18 @@ def predict(zedge, prev_zedge, max_ang, prev_freq, prev_length):
    # 'large' difference.
    diff1 = 1
    diff2 = 1
-   
+
    file = open('ImpactT.in', 'r')
    lines = file.readlines()
    file.close()
 
- 
+
    # make prediction for phase angle to make angular scan range smaller, reduce running time
 
    # First, we need to find the elapsed time between the time when the beam entered and exited
    # the previous cavity. This will be found by looking at fort.18_max because it is not easily
    # calculable (the beam is being accelerated).
-   
+
    # read in time from fort.18_max
    file = open('fort.18_max', 'r')
    lines18 = file.readlines()
@@ -332,7 +332,7 @@ def predict(zedge, prev_zedge, max_ang, prev_freq, prev_length):
          if diff_new2 < diff2:
             diff2 = diff_new2
             t2 = float(lines18[ind].split()[0])
-   
+
    # delt is the time elapsed between the beam entering and exiting the previous cavity
    print(float((lines18[ind].split())[1]),prev_zedge,prev_length)
    try:
@@ -380,7 +380,7 @@ def findMax(row, cav_end, prediction):
    ang_max = -1
 
    theta1 = prediction
-   
+
    if theta1 != -1:
       # Set new angular scan range to prediction +/- 20 degrees
       global angle_in
@@ -401,7 +401,7 @@ def findMax(row, cav_end, prediction):
       if (eng > eng_max):
          eng_max = eng
          ang_max = i
-      
+
    # If the maximum turns out to be either the max or min of the angular range, we have reason
    # to be suspicious that our initial prediction range doesn't contain the maximum.
    # This could be true either if:
@@ -414,11 +414,11 @@ def findMax(row, cav_end, prediction):
          print('i: ',i,eng)
          if (eng > eng_max):
             eng_max = eng
-            ang_max = i         
+            ang_max = i
 
    print('initial max angle: '+str(ang_max))
    print('initial max energy: '+str(eng_max))
-   
+
    # Set bracketed maximum triplet for Brent's method, along with corresponding energy values
    bracket_low = ang_max - 10
    bracket_high = ang_max + 10
@@ -436,7 +436,7 @@ def returnEng(ang, row, cav_end):
    # confines angle to 0-360 degrees
    ang = angMod(ang)
 
-   # We want fort.80 to contain the simulation information up to the previous beam element--this makes it so that 
+   # We want fort.80 to contain the simulation information up to the previous beam element--this makes it so that
    # we don't have to re-do that part of the simualtion. However, because of the way IMPACT-T runs, every time it
    # encounters a -3 line, it outputs data to fort.80. This is a problem because when we are testing multiple phase
    # angles for a single beam element, the fort.80 file that we are using to restart will contain information from
@@ -475,13 +475,13 @@ def returnEng(ang, row, cav_end):
    # file will be for that angle, and not the max energy.
 
    copyfile('fort.18','fort.18_max')
-   
+
    #os.system('tail -1 fort.18 >> tmpeng')
    tailAppend('fort.18','tmpeng')
-   
+
    os.system('echo '+str(ang)+' >> tmpphase')
-   
-   
+
+
    #os.system('paste tmpphase tmpeng > engout')
    pasteL('tmpphase','tmpeng','engout')
    os.remove('tmpeng')
@@ -502,10 +502,10 @@ def returnEng(ang, row, cav_end):
    print('----------')
 
    return float(eng)
-   
+
 # Brent's method of parabolic interpolation finds maximum given a bracketed triplet
 def brents(ax, bx, cx, fa, fb, fc, tol, it_max, row, cav_end):
-    
+
     print("Brent's method to find maximum with fractional tolerance " + str(tol) + "...")
     cgold = 0.3819660
     zeps = 0.0000000001
@@ -542,31 +542,31 @@ def brents(ax, bx, cx, fa, fb, fc, tol, it_max, row, cav_end):
               p = -p
            q = abs(q)
            etemp = e
-           
+
            # This line is in the example code for the Brent's method in 'Numerical Recipes in Fortran', but I'm not
            # sure what purpose it serves. It seems invalid since there is no previous declaration of 'd' in the first
            # iteration of this for loop.
-           #e = d  
+           #e = d
 
            # This is a clumsy workaround in trying to adapt code from 'Numerical Recipes in Fortran', in which
            # they use 'goto' statements, which don't exist in Python. I was able to recreate the basic structure
            # without too much repetitious code by having a single iteration 'for loop' that I could 'break' out of.
            for i in range(1):
-              
+
               # condition to determine acceptability of parabolic fit
               if (not ((abs(p) >= abs(0.5 * q * etemp)) or (p <= q * (a - x)) or (p >= q * (b - x)))):
                  # parabolic fit works
                  d = p / q
                  u = x + d
-                 
+
                  if (((u - a) < tol2) or ((b - u) < tol2)):
                     # skip over golden section step
                     break
-                 
+
                  else:
                     # do golden section step
                     if (x >= xm):
-                       e = a - x      
+                       e = a - x
                     else:
                        e = b - x
                        d = cgold * e
@@ -575,7 +575,7 @@ def brents(ax, bx, cx, fa, fb, fc, tol, it_max, row, cav_end):
               else:
                  # parabolic fit does not work
                  # do golden section step
-                 if (x >= xm): 
+                 if (x >= xm):
                     e = a - x
                  else:
                     e = b - x
@@ -619,7 +619,7 @@ def brents(ax, bx, cx, fa, fb, fc, tol, it_max, row, cav_end):
         # if the condition in line 187 is false, we still need to do the golden section step and everything
         # else that follows
         else:
-           if (x >= xm):  
+           if (x >= xm):
               e = a - x
            else:
               e = b - x
@@ -641,9 +641,9 @@ def brents(ax, bx, cx, fa, fb, fc, tol, it_max, row, cav_end):
                        x = u
                        fx = fu
                  else:
-                    if (u < x):  
+                    if (u < x):
                        a = u
-                    else:    
+                    else:
                        b = u
                        if ((fu >= fw) or (w == x)):
                           v = w
@@ -676,7 +676,7 @@ def tailAppend(src,dest):
     f2.write(li[-1])
     f1.close()
     f2.close()
-    
+
 def pasteL(src1,src2,dest):
     f1 = open(src1,'r')
     f2 = open(src2,'r')

--- a/GUI/src/SlicePlot.py
+++ b/GUI/src/SlicePlot.py
@@ -77,7 +77,7 @@ class SliceBaseFrame(tk.Frame):
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
         
         self.canvas = FigureCanvasTkAgg(self.fig, self)
-        self.canvas.show()
+        self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
         self.toolbar = NavigationToolbar2Tk(self.canvas, self)

--- a/GUI/src/SlicePlot.py
+++ b/GUI/src/SlicePlot.py
@@ -6,7 +6,7 @@ matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 
 import time,os,sys
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
 
@@ -80,7 +80,7 @@ class SliceBaseFrame(tk.Frame):
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
-        self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         

--- a/GUI/src/SlicePlot.py
+++ b/GUI/src/SlicePlot.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import time,os,sys
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
 from matplotlib.figure import Figure
-from matplotlib.ticker import MultipleLocator, FormatStrFormatter 
+from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 
 import numpy as np
 
@@ -19,12 +19,12 @@ class SliceBaseFrame(tk.Frame):
                     'Y slice emmittance (m-rad)':                   4,
                     'Energy spread per cell - Correlated (eV)':     5,
                     'Energy spread per cell - Uncorrelated (eV)':   6}
-    
+
     sciFormatter = FormatStrFormatter('%2.1E')
     sciMaxLimit  = 99999 *2
     sciMinLimit  = 0.0001*2
     data = np.array([])
-    
+
     def __init__(self, parent, PlotFileName):
         tk.Frame.__init__(self, parent)
         try:
@@ -32,12 +32,12 @@ class SliceBaseFrame(tk.Frame):
         except:
             print( "ERROR! Can't open file '" + PlotFileName + "'")
             return
-        
+
         self.data = np.transpose(self.data)
 
         self.frame_PlotControl = tk.Frame(self)
         self.frame_PlotControl.pack()
-        
+
         self.label_y    = tk.Label(self.frame_PlotControl, text='Axi:')
         self.label_y.pack(side='left')
         self.ppc2Value  = tk.StringVar(self.frame_PlotControl,'Current')
@@ -50,7 +50,7 @@ class SliceBaseFrame(tk.Frame):
                                                'Energy spread per cell - Correlated (eV)',
                                                'Energy spread per cell - Uncorrelated (eV)'])
         self.ppc2.pack(fill = 'both',expand =1,side = 'left')
-        
+
         LARGE_FONT= ("Verdana", 12)
         self.button_ppc=tk.Button(self.frame_PlotControl)
         self.button_ppc["text"]         = "Plot"
@@ -59,7 +59,7 @@ class SliceBaseFrame(tk.Frame):
         self.button_ppc["font"]         = LARGE_FONT
         self.button_ppc["command"]      = self.plot
         self.button_ppc.pack(fill = 'both',expand =1,side = 'right')
-        
+
         x   = 0
         try:
             y   = self.SlicePlotDirec[self.ppc2.get()]
@@ -67,35 +67,35 @@ class SliceBaseFrame(tk.Frame):
             print("SlicePlot Direction Error!")
             print("No "+self.ppc2.get() + "or " + y +" colume doesn't exist")
             self.quit()
-            
-        
+
+
         self.fig = Figure(figsize=(7,6), dpi=100)
         self.subfig = self.fig.add_subplot(111)
         self.subfig.plot(self.data[x],self.data[y])
-        
+
         box = self.subfig.get_position()
         self.subfig.set_position([box.x0*1.4, box.y0, box.width, box.height])
-        
+
         self.canvas = FigureCanvasTkAgg(self.fig, self)
         self.canvas.show()
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
-        
+
         self.toolbar = NavigationToolbar2TkAgg(self.canvas, self)
         self.toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        
+
         self.plot()
-        
+
     def plot(self):
         xData   = self.data[0]
         yData   = self.data[self.SlicePlotDirec[self.ppc2.get()]]
 
         self.subfig.cla()
-        
+
         self.subfig.plot(xData,yData)
         #self.subfig.relim()
         self.subfig.autoscale()
-        
+
         xMax = np.max(xData)
         xMin = np.min(xData)
         yMax = np.max(yData)
@@ -104,11 +104,10 @@ class SliceBaseFrame(tk.Frame):
             self.subfig.xaxis.set_major_formatter(self.sciFormatter)
         if (yMax-yMin)>self.sciMaxLimit or (yMax-yMin)<self.sciMinLimit:
             self.subfig.yaxis.set_major_formatter(self.sciFormatter)
-        
+
         self.subfig.set_xlabel('bunch length (m)')
         self.subfig.set_ylabel(self.ppc2.get())
         self.canvas.draw()
-        
+
     def quit(self):
         self.destroy()
-        

--- a/src/Contrl/AccSimulator.f90
+++ b/src/Contrl/AccSimulator.f90
@@ -764,6 +764,8 @@
 !for switch integrator: -18
         integer :: flaginteg = 0
         real*8, dimension(101) :: tinteg
+! for diagnostic output per bunch
+        integer :: file_offset
 !--------------
 ! dielectric wakefield module implemented by Daniel Mihalcea:
 ! PRST-AB, 15, 081304, (2012).
@@ -1159,6 +1161,13 @@
         enddo
         nplocal0 = Nplocal(1)
         np0 = Np(1)
+
+        ! Output the moments from each bunch at fixed t to separate files
+        DO ib = 1, Nbunch
+          file_offset = 1000 * ib
+          CALL diagnostic1_Output(t, Ebunch(ib), file_offset)
+        END DO
+
         if(Flagdiag.eq.1) then
           !output the moments from the average of all bunches at fixed t.
           call diagnostic1avg_Output(t,Ebunch,Nbunch)
@@ -2080,6 +2089,12 @@
  
           !output for every 5 steps
           if(mod(i,5).eq.0) then
+
+          ! Output the moments from each bunch at fixed t to separate files
+          DO ib = 1, Nbunch
+            file_offset = 1000 * ib
+            CALL diagnostic1_Output(t, Ebunch(ib), file_offset)
+          END DO
 
           if(Flagdiag.eq.1) then
             call diagnostic1avg_Output(t,Ebunch,Nbunch)

--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -20,11 +20,12 @@
       contains
         !> calculate <x^2>,<xp>,<px^2>,x emittance, <y^2>,<ypy>,
         !> <py^2> and y emittance, <z^2>,<zp>,<pz^2>,z emittance.
-        subroutine diagnostic1_Output(z,this)
+        subroutine diagnostic1_Output(z,this,file_offset)
         implicit none
         include 'mpif.h'
         double precision, intent(in) :: z
         type (BeamBunch), intent(inout) :: this
+        integer, intent(in) :: file_offset
         integer :: innp,nptot
         double precision:: den1,den2,sqsum1,sqsum2,sqsum3,sqsum4,&
                           epsx2,epsy2
@@ -273,35 +274,36 @@
           gam = sqrt(1.0+px0**2+py0**2+pz0**2)
           energy = qmc*(gam-1.0)
           bet = sqrt(1.0-(1.0/gam)**2)
-          write(18,99)z,z0avg*xl,gam,energy,bet,sqrt(glrmax)*xl
+          write(18+file_offset,99)z,z0avg*xl,gam,energy,bet,sqrt(glrmax)*xl
 !          write(24,100)z,x0*xl,xrms*xl,px0,pxrms,-xpx/epx,epx*xl
 !          write(25,100)z,y0*xl,yrms*xl,py0,pyrms,-ypy/epy,epy*xl
 !          write(26,100)z,z0*xl,zrms*xl,pz0,pzrms,-zpz/epz,epz*xl
-          write(24,100)z,x0*xl,xrms*xl,px0,pxrms,-xpx,epx*xl
-          write(25,100)z,y0*xl,yrms*xl,py0,pyrms,-ypy,epy*xl
-          write(26,100)z,z0*xl,zrms*xl,pz0,pzrms,-zpz,epz*xl
+          write(24+file_offset,100)z,z0avg*xl,x0*xl,xrms*xl,px0,pxrms,-xpx*xl,epx*xl
+          write(25+file_offset,100)z,z0avg*xl,y0*xl,yrms*xl,py0,pyrms,-ypy*xl,epy*xl
+          write(26+file_offset,101)z,z0avg*xl,zrms*xl,pz0,pzrms,-zpz*xl,epz*xl
 
-          write(27,100)z,glmax(1)*xl,glmax(2),glmax(3)*xl,&
+          write(27+file_offset,100)z,z0avg*xl,glmax(1)*xl,glmax(2),glmax(3)*xl,&
                        glmax(4),glmax(5)*xl,glmax(6)
-          write(28,101)z,npctmin,npctmax,nptot
-          write(29,100)z,x03*xl,px03,y03*xl,py03,z03*xl,&
+          write(28+file_offset,102)z,z0avg*xl,npctmin,npctmax,nptot
+          write(29+file_offset,100)z,z0avg*xl,x03*xl,px03,y03*xl,py03,z03*xl,&
                        pz03
-          write(30,100)z,x04*xl,px04,y04*xl,py04,z04*xl,&
+          write(30+file_offset,100)z,z0avg*xl,x04*xl,px04,y04*xl,py04,z04*xl,&
                        pz04
 
-          call flush(18)
-          call flush(24)
-          call flush(25)
-          call flush(26)
-          call flush(27)
-          call flush(28)
-          call flush(29)
-          call flush(30)
+          call flush(18+file_offset)
+          call flush(24+file_offset)
+          call flush(25+file_offset)
+          call flush(26+file_offset)
+          call flush(27+file_offset)
+          call flush(28+file_offset)
+          call flush(29+file_offset)
+          call flush(30+file_offset)
         endif
 
-99      format(6(1x,e13.6))
-100      format(7(1x,e13.6))
-101     format(1x,e13.6,3I10)
+99      format(6(1x,e16.8))
+100     format(8(1x,e16.8))
+101     format(7(1x,e16.8))
+102     format(1x,e16.8,e16.8,3I10)
 
         t_diag = t_diag + elapsedtime_Timer(t0)
 


### PR DESCRIPTION
## Description

Adds six new plots with multiple bunches:
* Beam size (rms)
* Emittance
* Emittance growth
* Energy
* Combined energy (log-scale)
* Combined phase space

Can include all bunches or only a selected number of bunches.

Beam size, emittance and emittance growth are plotted against time t or location z.
Each bunch is plotted as a dotted line, and a combined value for all bunches as a solid line.
Also plots experimental data for beam size alongside the simulation results.

Energy spectra are plotted as histograms, including a combined plot for all bunches combined.

Phase space plots are generated using Matplotlib's `hist2d` function, which is much faster than the custom method use for the single-file phase space plots.
Also added 1D histograms to the axes.

MultiBunchPlot.py can also be run as a script, outputting all files as PNG images, and can be run on a headless server.
The bunches to plot can be given as a command-line parameter.


## Dependencies

This depends on a number of other pull requests:
* #9: Fix GUI plotting code for newer versions of Matplotlib
* #4: Fix line endings
* #8: Add per-bunch output files

These have already been merged into this branch, so this pull request should only be merged after the above have already been merged into the master branch. At that point, this current pull request should be rebased.

The commit with the actual multi-bunch plotting changes is fa6373b5.


## Example plots

### Emittance

![2020-03-31-1 0e-14-no-spacecharge-emittance](https://user-images.githubusercontent.com/8106497/79276423-e24fc580-7e9f-11ea-84f3-b99c7a7cee06.png)

### Energy

![2020-04-14-energies-initial](https://user-images.githubusercontent.com/8106497/79276207-7e2d0180-7e9f-11ea-8321-8917114ccbc8.png)

### Phase space

![2020-04-14-phase-space-initial](https://user-images.githubusercontent.com/8106497/79276122-55a50780-7e9f-11ea-9165-fa97cb909f76.png)
