### PR TITLE
Avoid argument mismatch errors with gcc v10

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@
 
 CC = ifort
 LINK = ifort
-FFLAGS = -O3
+FFLAGS = -fallow-argument-mismatch -O3
 
 #**************************************************************************
 # List of .o files that EXENAME depends on.  Edit as appropriate for MP.


### PR DESCRIPTION
MPI routines use implicit typing in parameters passed as a buffer, which flags as an error in gcc v10.

This change downgrades that error to a warning.

An example of the reported error is:

```log
DataStruct/Data.f90:1405:23:
 1402 |         call MPI_BCAST(this%NxIntvRfgt,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
      |                       2
......
 1405 |         call MPI_BCAST(this%XminRfgt,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
      |                       1
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/INTEGER(4)).
```

Here, `MPI_BCAST` is called with different-type parameters, but this is not an error, as `MPI_BCAST` can handle the different buffer types.

For more information, see [this GCC bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556).