### PR TITLE
Allow tracking of subset of particles filtered by energy range

### DIFF
--- a/src/Appl/Quadrupole.f90
+++ b/src/Appl/Quadrupole.f90
@@ -2,10 +2,13 @@
 ! (c) Copyright, 2017 by the Regents of the University of California.
 ! Quadrupoleclass: Quadrupole beam line element class
 !             in Lattice module of APPLICATION layer.
-! Version: 1.0
-! Author: Ji Qiang
-! Description: This class defines the linear transfer map and field
-!              for the quadrupole beam line elment.
+! MODULE  : ... Quadrupoleclass
+! VERSION : ... 1.0
+!> @author
+!> Ji Qiang
+! DESCRIPTION:
+!> This class defines the linear transfer map and field
+!> for the quadrupole beam line elment.
 ! Comments:
 !----------------------------------------------------------------
       module Quadrupoleclass
@@ -120,7 +123,10 @@
         end subroutine getparam3_Quadrupole
        
 
-        !get external field with displacement and rotation errors.
+        !--------------------------------------------------------------------------------------
+        !> @brief
+        !> get external field with displacement and rotation errors.
+        !--------------------------------------------------------------------------------------
         subroutine  getflderr_Quadrupole(pos,extfld,this,dx,dy,anglex,&
                                          angley,anglez)
         implicit none
@@ -203,8 +209,11 @@
 
         end subroutine getflderr_Quadrupole
         
-        !get external field without displacement and rotation errors.
-        !here, the skew quad can can be modeled with nonzero anglez
+        !--------------------------------------------------------------------------------------
+        !> @brief
+        !> get external field without displacement and rotation errors.
+        !> here, the skew quad can can be modeled with nonzero anglez
+        !--------------------------------------------------------------------------------------
         subroutine getfld_Quadrupole(pos,extfld,this)
         implicit none
         include 'mpif.h'
@@ -267,7 +276,10 @@
 
         end subroutine getfld_Quadrupole
 
-        !interpolate the field from the SC rf cavity onto bunch location.
+        !--------------------------------------------------------------------------------------
+        !> @brief
+        !> interpolate the field from the SC rf cavity onto bunch location.
+        !--------------------------------------------------------------------------------------
         subroutine getfldfrg_Quadrupole(zz,this,bgrad)
         implicit none
         include 'mpif.h'
@@ -371,7 +383,10 @@
  
         end subroutine getfldfrgAna2_Quadrupole
 
-        !get external field with displacement and rotation errors.
+        !--------------------------------------------------------------------------------------
+        !> @brief
+        !> get external field with displacement and rotation errors.
+        !--------------------------------------------------------------------------------------
         subroutine  getflderrt_Quadrupole(pos,extfld,this)
         implicit none
         include 'mpif.h'

--- a/src/Contrl/AccSimulator.f90
+++ b/src/Contrl/AccSimulator.f90
@@ -204,13 +204,8 @@
               Flagmap,distparam,Ndistparam,Bcurr,Bkenergy,Bmass,Bcharge,&
         Bfreq,xrad,yrad,Perdlen,Nblem,npcol,nprow,Flagerr,Flagdiag,&
         Flagsubstep,phsini,dt,ntstep,Nbunch,FlagImage,Nemission,&
-        temission,zimage)
+        temission,zimage,FlagEnergyRange,filter_min,filter_max)
  
-        ! Hard-code energy range for testing - should be included in input file
-        FlagEnergyRange = 1
-        filter_min =  95.0e6  ! eV
-        filter_max = 105.0e6  ! eV
-
 !        print*,"Np: ",Np,dt,ntstep,Nx,Ny,Nz
 !        print*,"Bcurr: ",Bcurr,Bkenergy,Bmass,Bcharge,Bfreq
 !-------------------------------------------------------------------

--- a/src/Contrl/AccSimulator.f90
+++ b/src/Contrl/AccSimulator.f90
@@ -18,12 +18,17 @@
 !****************************
 !
 ! AccSimulatorclass: Linear accelerator simulator class in CONTROL layer.
-! Version: 2.1
-! Author: Ji Qiang
-! Description: This class defines functions to set up the initial beam 
-!              particle distribution, field information, computational
-!              domain, beam line element lattice and run the dynamics
-!              simulation through the system.
+! 
+! MODULE  : ... AccSimulatorclass
+! VERSION : ... 2.0
+!> @author
+!> Ji Qiang
+!
+! DESCRIPTION: 
+!> This class defines functions to set up the initial beam 
+!> particle distribution, field information, computational
+!> domain, beam line element lattice and run the dynamics
+!> simulation through the system.
 ! Comments:
 !----------------------------------------------------------------
       module AccSimulatorclass
@@ -43,62 +48,83 @@
         use Rangerclass
         use Depositorclass
         implicit none
-        !# of phase dim., num. total and local particles, int. dist. 
-        !and restart switch, error study switch, substep for space-charge
-        !switch,# of time step
+        !> @name
+        !! \# of phase dim., num. total and local particles, int. dist. 
+        !! and restart switch, error study switch, substep for space-charge
+        !! switch, \# of time step
+        !> @{
         integer :: Dim, Flagdist,Rstartflg,Flagerr,&
                             Flagsubstep,ntstep 
         integer, dimension(Nbunchmax) :: Np, Nplocal
-        !# of num. total x, total and local y mesh pts., type of BC, 
-        !# of beam elems, type of integrator.
-        !FlagImage: switch flag for image space-charge force calculation: "1" for yes, 
-        !otherwise for no. 
+        !> @}
+
+        !> @name
+        !! \# of num. total x, total and local y mesh pts., type of BC, 
+        !! \# of beam elems, type of integrator.
+        !! FlagImage: switch flag for image space-charge force calculation: "1" for yes, 
+        !! otherwise for no. 
+        !> @{
         integer :: Nx,Ny,Nz,Nxlocal,Nylocal,Nzlocal,Flagbc,&
                             Nblem,Flagmap,Flagdiag,FlagImage
+        !> @}
 
-        !# of processors in column and row direction.
+        !> @name                    
+        !! \# of processors in column and row direction.
+        !> @{
         integer :: npcol, nprow
+        !> @}
 
-        !initial # of bunches/bins
-        integer :: Nbunch
+        !> initial \# of bunches/bins
+        integer :: Nbunch 
 
-        !beam current, kin. energy, part. mass, charge, ref. freq., period length, 
-        !time step size 
+        !> @name
+        !! beam current, kin. energy, part. mass, charge, ref. freq., period length, 
+        !! time step size 
+        !> @{
         double precision :: Bcurr,Bkenergy,Bmass,Bcharge,Bfreq,&
                                      Perdlen,dt,xrad,yrad
+        !> @}
 
-        !conts. in init. dist.
+        !> @name
+        !! conts. in init. dist.
+        !> @{
         integer, parameter :: Ndistparam = 21
         double precision, dimension(Ndistparam) :: distparam
+        !> @}
 
-        !2d logical processor array.
-        type (Pgrid2d) :: grid2d
+        !> 2d logical processor array
+        type (Pgrid2d) :: grid2d 
 
-        !beam particle object and array.
+        !> beam particle object and array.
         type (BeamBunch), dimension(Nbunchmax) :: Ebunch
 
-        !beam charge density and field potential arrays.
+        !> beam charge density and field potential arrays.
         type (FieldQuant) :: Potential
 
-        !geometry object.
+        !> geometry object.
         type (CompDom) :: Ageom
 
-        !overlaped external field data array
+        !> overlaped external field data array
         type (fielddata), dimension(Maxoverlap) :: fldmp
 
-        !maximum e- emission time
+        !> maximum e- emission time
         double precision :: temission
-        !number of steps for emission
+        !> number of steps for emission
         integer :: Nemission
 
-        !distance after that to turn off image space-charge
+        !> distance after that to turn off image space-charge
         double precision :: zimage
 
-        !restart time and step
+        !> @name
+        !! restart time and step
+        !> @{
         double precision :: tend,dtlessend
         integer :: iend,ibchend,nfileout,ioutend,itszend,isteerend,isloutend
+        !> @}
 
-        !beam line element array.
+        !> @name 
+        !! beam line element array.
+        !> @{
         type (BPM),target,dimension(Nbpmmax) :: beamln0
         type (DriftTube),target,dimension(Ndriftmax) :: beamln1
         type (Quadrupole),target,dimension(Nquadmax) :: beamln2
@@ -116,14 +142,16 @@
         type (EMfldAna),target,dimension(Ncclmax) :: beamln14
         type (Multipole),target,dimension(Nquadmax) :: beamln15
         type (BeamLineElem),dimension(Nblemtmax)::Blnelem
-        !longitudinal position of each element (min and max).
+        !> @}
+
+        !> longitudinal position of each element (min and max).
         double precision, dimension(2,Nblemtmax)::zBlnelem
-        !beam line element period.
+        !> beam line element period.
         interface construct_AccSimulator
           module procedure init_AccSimulator
         end interface
       contains
-        !set up objects and parameters.
+        !> set up objects and parameters.
         subroutine init_AccSimulator(time)
         implicit none
         include 'mpif.h'
@@ -151,7 +179,7 @@
         real*8 rancheck
         integer :: seedsize
 
-        !start up MPI.
+        ! start up MPI.
         call init_Input(time)
 
         ! initialize Timer.
@@ -614,7 +642,7 @@
 
         end subroutine init_AccSimulator
 
-        !Run beam dynamics simulation through accelerator.
+        !> Run beam dynamics simulation through accelerator.
         subroutine run_AccSimulator()
         implicit none
         include 'mpif.h'
@@ -1210,7 +1238,7 @@
             imap = imap + 1
             do ib = 1, Nbunch
 
-            !//find the range and center information of each bunch/bin
+              !//find the range and center information of each bunch/bin
               call singlerange(Ebunch(ib)%Pts1,Nplocal(ib),Np(ib),&
                              ptrange,sgcenter)
 

--- a/src/Contrl/Input.f90
+++ b/src/Contrl/Input.f90
@@ -41,20 +41,20 @@
         orstartflg,oflagmap,distparam,nparam,obcurr,obkenergy,obmass,&
         obcharge,obfreq,oxrad,oyrad,operdlen,onblem,onpcol,onprow,oflagerr,&
         oflagdiag,oflagsbstp,ophsini,odt,ontstep,onbunch,oflagimg,&
-        onemission,otemission,ozimage)
+        onemission,otemission,ozimage,oFlagRange,oRangeMin,oRangeMax)
 
         implicit none
         include 'mpif.h'
         integer, intent(out) :: odim,onp,onx,ony,onz,oflagbc,oflagdist
         integer, intent(out) :: orstartflg,oflagmap,onblem,onpcol,onprow 
         integer, intent(out) :: oflagerr,oflagdiag,oflagsbstp,ontstep,&
-                                onbunch,oflagimg,onemission
+                                onbunch,oflagimg,onemission,oFlagRange
         integer, intent(in) :: nparam
         double precision, dimension(nparam), intent(out) :: distparam
         double precision, intent(out) :: obcurr,obkenergy,obmass,odt
         double precision, intent(out) :: obcharge,obfreq,operdlen,&
                                          oxrad,oyrad,ophsini,&
-                                         otemission,ozimage
+                                         otemission,ozimage,oRangeMin,oRangeMax
         double precision :: xjunk
         integer :: my_rank,nproc,ierr,np,itot,njunk1,njunk2,njunk3
         character*1 comst
@@ -105,6 +105,7 @@
           else
             backspace(13,err=789)
             read(13,*)odim,onp,oflagmap,oflagerr,oflagdiag,oflagimg,ozimage 
+            call readbonusflags_Input(13, oFlagRange, oRangeMin, oRangeMax)
             ii = ii+1
           endif
 40        continue
@@ -243,6 +244,9 @@
                          ierr)
         call MPI_BCAST(ophsini,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,&
                          ierr)
+        call MPI_BCAST(oFlagRange, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+        call MPI_BCAST(oRangeMin, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+        call MPI_BCAST(oRangeMax, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
         end subroutine in1_Input
 
@@ -386,7 +390,7 @@
 
         end subroutine in2_Input
 
-        !> Input all parameters except beam line element parameters.
+        !> Input parameters for subsequent bunches.
         subroutine in3_Input(odim,onp,onx,ony,onz,oflagbc,oflagdist, &
         orstartflg,oflagmap,distparam,nparam,obcurr,obkenergy,obmass,&
         obcharge,obfreq,oxrad,oyrad,operdlen,onblem,onpcol,onprow,oflagerr,&
@@ -618,5 +622,59 @@
                          ierr)
 
         end subroutine in3_Input
-      end module Inputclass
+
+    !> Read in any bonus flags for additional modules that are not part of the
+    !> standard input file.
+    !> - This allows adding extra module flags without needing to
+    !>   change all existing input files, assisting backwards compatibility.
+    !> - This is called *after* the standard reading of the line with the
+    !>   main flags on, so starts by backing up the file and reading the
+    !>   line again.
+    !> - At the end of the routine, the file should be ready to continue
+    !>   reading as normal.
+    subroutine readbonusflags_Input(fileunit, flag_range, range_min, range_max)
+        ! Parameters
+        integer,          intent(in)  :: fileunit
+        integer,          intent(out) :: flag_range
+        double precision, intent(out) :: range_min, range_max
+        ! Variables
+        integer          :: dim_in, np_in, flagmap_in, flagerr_in, &
+                            flagdiag_in, flagimg_in
+        integer          :: dim_chk, np_chk, flagmap_chk
+        double precision :: zimage_in
+        integer          :: ierr
+
+        ! Read the last input line again with the bonus flags included
+        backspace(fileunit)
+        read(fileunit, *, iostat=ierr) dim_in, np_in, flagmap_in, flagerr_in, &
+                                        flagdiag_in, flagimg_in, zimage_in, &
+                                        flag_range, range_min, range_max
+
+        ! If we hit an error at this point, it's probably because
+        !  there are no bonus flags
+        if(ierr /= 0) then
+            flag_range = 0
+            range_min = 0.0d0
+            range_max = 0.0d0
+            backspace(fileunit)
+            return
+        endif
+
+        ! Read in the first few standard flags again and compare
+        !  - this is to check that we haven't moved to the next line
+        backspace(fileunit)
+        read(fileunit, *, iostat=ierr) dim_chk, np_chk, flagmap_chk
+        if((ierr /= 0).or.(dim_chk /= dim_in) &
+                        .or.(np_chk /= np_in)   &
+                        .or.(flagmap_chk /= flagmap_in)) then
+            flag_range = 0
+            range_min = 0.0d0
+            range_max = 0.0d0
+            backspace(fileunit)
+            return
+        endif
+
+    end subroutine readbonusflags_Input
+
+end module Inputclass
 

--- a/src/DataStruct/Data.f90
+++ b/src/DataStruct/Data.f90
@@ -1,13 +1,18 @@
 !----------------------------------------------------------------
 ! (c) Copyright, 2017 by the Regents of the University of California.
 ! Dataclass: Field data class in DATA STRUCTURE layer.
-! Version: 1.0
-! Author: Ji Qiang 
-! Description: This class stores the rf cavity data Ez, Ez', Ez'' on the 
-!              axis; Fourier coefficients of Ez on the axis; Ez(r,z),
-!              Er(r,z), Htheta(r,z) on the r-z grid plane; and Ex(x,y,z),
-!              Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z), Bz(x,y,z) on
-!              uniform x, y, z grid, and Br(r,z) and Bz(r,z) on the r-z grid.
+!
+! MODULE  : ... Dataclass
+! VERSION : ... 1.0
+!> @author
+!> Ji Qiang 
+!
+! DESCRIPTION: 
+!> This class stores the rf cavity data Ez, Ez', Ez'' on the 
+!> axis; Fourier coefficients of Ez on the axis; Ez(r,z),
+!> Er(r,z), Htheta(r,z) on the r-z grid plane; and Ex(x,y,z),
+!> Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z), Bz(x,y,z) on
+!> uniform x, y, z grid, and Br(r,z) and Bz(r,z) on the r-z grid.
 ! Comments: 
 !----------------------------------------------------------------
       module Dataclass
@@ -15,45 +20,95 @@
         use mpistub
 !        save
 !-----------------------------------------------------------------------
-! using the x-y-z field data (Ex,Ey,Ez,Bx,By,Bz) directly.
-        !number of grid points along x, y, and z direction.
+!> @name
+
+!> @{
+!> using the x-y-z field data (Ex,Ey,Ez,Bx,By,Bz) directly.
+        !> @name
+
+        !> @{
+        !> number of grid points along x, y, and z direction.
         integer :: NxIntvRfg = 1
         integer :: NyIntvRfg = 1
         integer :: NzIntvRfg = 1
-        !range in x, y, and zdirections.
+        !> @}
+        !> @name
+
+        !> @{
+        !> range in x, y, and zdirections.
         double precision :: XmaxRfg,XminRfg,YmaxRfg,YminRfg,ZmaxRfg,ZminRfg
-        ! discrete Ex(x,y,z), Ey(x,y,z), Ez(x,y,z) and Bx(x,y,z), By(x,y,z), and 
-        ! Bz(x,y,z) rf data. Here, the grid is uniform in x, y and z.
+        !> @}
+        !> @name
+
+        !> @{
+        !> discrete Ex(x,y,z), Ey(x,y,z), Ez(x,y,z) and Bx(x,y,z), By(x,y,z), and 
+        !> Bz(x,y,z) rf data. Here, the grid is uniform in x, y and z.
         double precision,allocatable,dimension(:,:,:) :: &
                Exgrid,Eygrid,Ezgrid,Bxgrid,Bygrid,Bzgrid
+        !> @}
+!> @}
 !-----------------------------------------------------------------------
-! using the r-z field data (Er,Ez,Htheta) directly.
-        !number of grid points along r direction.
+!> @name
+!> @{
+!> using the r-z field data (Er,Ez,Htheta) directly.
+        !> @name
+
+        !> @{
+        !> number of grid points along r direction.
         integer :: NrIntvRf = 1
-        !number of grid points along z direction.
+        !> number of grid points along z direction.
         integer :: NzIntvRf = 1
-        !range in r and z directions.
+        !> @}
+        !> @name
+
+        !> @{ 
+        !> range in r and z directions.
         double precision :: RmaxRf,RminRf,ZmaxRf,ZminRf
-        ! discrete Ez(r,z), Er(r,z) and Htheta(r,z) rf data. Here, the grid
-        ! is uniform in r and z.
+        !> @}
+        !> @name
+
+        !> @{
+        !> discrete Ez(r,z), Er(r,z) and Htheta(r,z) rf data. Here, the grid
+        !> is uniform in r and z.
         double precision,allocatable,dimension(:,:) :: &
                ezdata,erdata,btdata
+        !> @}
+!> @}
 !-----------------------------------------------------------------------
-! using only on-axis field data and its derivities.
-        !initial number of grid points on the axis.
+!> @name
+!> @{
+!> using only on-axis field data and its derivities.
+        !> @name
+               
+        !> @{
+        !> initial number of grid points on the axis.
         integer, parameter :: Ndataini = 5000
-        ! discrete Ez(0,z), Ez'(0,z), Ez''(0,z) rf data.
+        !> @}
+        !> @name
+
+        !> @{
+        !> discrete Ez(0,z), Ez'(0,z), Ez''(0,z) rf data.
         double precision,dimension(Ndataini) :: zdat,edat,epdat,eppdat
+        !> @}
+!> @}
 !----------------------------------------------------------------------
-! using the Fourier coefficients
-        !number of Fourier expansion coefficients.
+!> @name
+!> @{
+!> using the Fourier coefficients
         integer, parameter :: NcoefF = 401
-        double precision,dimension(NcoefF) :: Fcoef
+        double precision,dimension(NcoefF) :: Fcoef 
+        !> @name
+
+        !> @{
+        !> number of Fourier expansion coefficients.
+        !> @}
+        
         !Fcoef(1): constant
         !Fcoef(2k): cosine term
         !Fcoef(2k+1): sine term
+!> @}
 !----------------------------------------------------------------------
-        ! practical number of grid data on the axis or Fourier coefficients.
+        !> practical number of grid data on the axis or Fourier coefficients.
         integer :: Ndata
 !------------------------------------------------------------------------
 !
@@ -61,54 +116,78 @@
         type fielddata
           ! using the x-y-z field data (Ex,Ey,Ez,Bx,By,Bz) 
           !directly for beam line element i.
-          !number of grid points along x, y, and z direction.
+          !> @name 
+
+          !> @{
+          !> number of grid points along x, y, and z direction.
           integer :: NxIntvRfgt 
           integer :: NyIntvRfgt
           integer :: NzIntvRfgt
-          !range in x, y, and zdirections.
+          !> @}
+          !> @name
+
+          !> @{
+          !> range in x, y, and zdirections.
           double precision  :: XmaxRfgt,XminRfgt,&
                YmaxRfgt,YminRfgt,ZmaxRfgt,ZminRfgt
-          ! discrete Ex(x,y,z,i), Ey(x,y,z,i), Ez(x,y,z,i) and Bx(x,y,z,i), 
-          ! By(x,y,z,i), and
-          ! Bz(x,y,z,i) rf data. Here, the grid is uniform in x, y and z.
+          !> @}
+          !> @name
+
+          !> @{
+          !> discrete Ex(x,y,z,i), Ey(x,y,z,i), Ez(x,y,z,i) and Bx(x,y,z,i), 
+          !> By(x,y,z,i), and
+          !> Bz(x,y,z,i) rf data. Here, the grid is uniform in x, y and z.
           double complex,pointer,dimension(:,:,:) :: &
                Exgridt,Eygridt,Ezgridt,Bxgridt,Bygridt,Bzgridt
+          !> @}
           ! using the r-z field data (Er,Ez,Htheta) directly.
-          !number of grid points along r direction.
+          !> number of grid points along r direction.
           integer :: NrIntvRft
-          !number of grid points along z direction.
+          !> number of grid points along z direction.
           integer :: NzIntvRft 
-          !range in r and z directions.
+          !> @name
+
+          !> @{
+          !> range in r and z directions.
           double precision :: RmaxRft,RminRft,&
               ZmaxRft,ZminRft
-          ! discrete Ezt(r,z,i), Ert(r,z,i) and 
-          ! Btheta(r,z,i) rf data. Here, the grid
-          ! is uniform in r and z.
+          !> @}
+          !> @name
+
+          !> @{
+          !> discrete Ezt(r,z,i), Ert(r,z,i) and 
+          !> Btheta(r,z,i) rf data. Here, the grid
+          !> is uniform in r and z.
           double precision,pointer,dimension(:,:) :: &
                ezdatat,erdatat,btdatat,brdatat,bzdatat
+          !> @}
           ! using the analytical function for field data 
           ! (Ex,Ey,Ez,Bx,By,Bz) for beam line element i directly.
-          !number of coefficients in Ex.
+          !> number of coefficients in Ex.
           integer :: Ncex 
-          !number of coefficients in Ey.
+          !> number of coefficients in Ey.
           integer :: Ncey 
-          !number of coefficients in Ez.
+          !> number of coefficients in Ez.
           integer :: Ncez 
-          !number of coefficients in Bx.
+          !> number of coefficients in Bx.
           integer :: Ncbx
-          !number of coefficients in By.
+          !> number of coefficients in By.
           integer :: Ncby
-          !number of coefficients in Bz.
+          !> number of coefficients in Bz.
           integer :: Ncbz 
-          !coefficients for analytical function description of the rf data.
+          !> @name 
+          
+          !> @{
+          !> coefficients for analytical function description of the rf data.
           double precision,pointer,dimension(:) :: &
               coefex,coefey,coefez,coefbx,coefby,coefbz
+          !> @}
           ! using the Fourier coefficients
           !integer, parameter :: NcoefFt = 401
-          ! practical number of grid data on the axis or Fourier coefficients.
+          !> practical number of grid data on the axis or Fourier coefficients.
           double precision,dimension(401) :: Fcoeft
           !store the discrete data of ez,ez',ez'',ez''' on axis. 
-          !here, maximum data point is 5000 for E field or B field.
+          !> here, maximum data point is 5000 for E field or B field.
           double precision,dimension(4,10002) :: Fcoeftdata
           integer :: Ndatat
         end type fielddata
@@ -117,7 +196,7 @@
 !-------------------------------------------------------------------------
 ! the following are used to store the field data in position z domain, i.e.
 ! used by Impact-Z code.
-        !Initialize the data storage arrays.
+        !> Initialize the data storage arrays.
         subroutine init_Data()
         implicit none
         include 'mpif.h' 
@@ -191,9 +270,9 @@
          
         end subroutine destruct_Data
 
-        !read in the discrete field data Ez(0,z), Ez'(0,z), Ez''(0,z) 
-        !distribution along axis zdat from files "rfdatax or rfdataxx 
-        !or rfdataxxx".
+        !> read in the discrete field data Ez(0,z), Ez'(0,z), Ez''(0,z) 
+        !> distribution along axis zdat from files "rfdatax or rfdataxx 
+        !> or rfdataxxx".
         subroutine read1_Data(ifile)
         implicit none
         include 'mpif.h'
@@ -272,9 +351,9 @@
         !print*,"Ndata: ",Ndata
         end subroutine read1_Data
 
-        ! read in discrete Ez(r,z), Er(r,z) and Btheta(r,z) rf data from
-        ! files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
-        ! is uniform in r and z.
+        !> read in discrete Ez(r,z), Er(r,z) and Btheta(r,z) rf data from
+        !> files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
+        !> is uniform in r and z.
         subroutine read2_Data(ifile)
         implicit none
         include 'mpif.h' 
@@ -401,8 +480,8 @@
         !print*,"Ndata: ",Ndatalc
         end subroutine read2_Data
 
-        !readin the Fourier coefficients of the RF field from files 
-        !"rfdatax or rfdataxx or rfdataxxx".
+        !> readin the Fourier coefficients of the RF field from files 
+        !> "rfdatax or rfdataxx or rfdataxxx".
         subroutine read3_Data(ifile)
         implicit none
         include 'mpif.h'
@@ -466,10 +545,10 @@
         !print*,"Ndata: ",Ndata
         end subroutine read3_Data
 
-        ! read in discrete Ex(x,y,z), Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z),
-        ! Bz(x,y,z) rf data from
-        ! files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
-        ! is uniform in x, y and z.
+        !> read in discrete Ex(x,y,z), Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z),
+        !> Bz(x,y,z) rf data from
+        !> files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
+        !> is uniform in x, y and z.
         subroutine read4_Data(ifile)
         implicit none
         include 'mpif.h' 
@@ -718,8 +797,8 @@
          
         end subroutine destructt_Data
 
-        !readin the Fourier coefficients of the RF field from files 
-        !"rfdatax or rfdataxx or rfdataxxx".
+        !> readin the Fourier coefficients of the RF field from files 
+        !> "rfdatax or rfdataxx or rfdataxxx".
         subroutine read1t_Data(this,ifile)
         implicit none
         include 'mpif.h'
@@ -785,8 +864,8 @@
         print*,"Ndata: ",this%Ndatat
         end subroutine read1t_Data
 
-        !readin the Fourier coefficients of the RF field from files 
-        !"rfdatax or rfdataxx or rfdataxxx".
+        !> readin the Fourier coefficients of the RF field from files 
+        !> "rfdatax or rfdataxx or rfdataxxx".
         subroutine read1tdata_Data(this,ifile)
         implicit none
         include 'mpif.h'
@@ -875,9 +954,9 @@
 
         !J.Q. changed the format of inputs (7/28/2020) to the new
         !Superfilsh RF cavity output.
-        ! read in discrete Ez(r,z), Er(r,z) and Btheta(r,z) rf data from
-        ! files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
-        ! is uniform in r and z.
+        !> read in discrete Ez(r,z), Er(r,z) and Btheta(r,z) rf data from
+        !> files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
+        !> is uniform in r and z.
         subroutine read2t_Data(this,ifile)
         implicit none
         include 'mpif.h' 
@@ -1152,10 +1231,10 @@
         !print*,"Ndata: ",Ndatalc
         end subroutine read2told_Data
 
-        ! read in analytical function coefficients of 
-        ! Ex(x,y,z), Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z),
-        ! Bz(x,y,z) rf data from
-        !"rfdatax or rfdataxx or rfdataxxx".
+        !> read in analytical function coefficients of 
+        !> Ex(x,y,z), Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z),
+        !> Bz(x,y,z) rf data from
+        !> "rfdatax or rfdataxx or rfdataxxx".
         subroutine read4t_Data(this,ifile)
         implicit none
         include 'mpif.h'
@@ -1259,9 +1338,9 @@
         print*,"Ndata: ",this%Ndatat
         end subroutine read4t_Data
 
-        ! read in discrete Bz(r,z), Br(r,z) data from
-        ! files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7 for solenoid. Here, the grid
-        ! is uniform in r and z.
+        !> read in discrete Bz(r,z), Br(r,z) data from
+        !> files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7 for solenoid. Here, the grid
+        !> is uniform in r and z.
         subroutine read2tsol_Data(this,ifile)
         implicit none
         include 'mpif.h' 
@@ -1386,11 +1465,11 @@
         !print*,"Ndata: ",Ndatalc
         end subroutine read2tsol_Data
 
-        ! read in discrete complex Ex(x,y,z), Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z),
-        ! Bz(x,y,z) rf data from
-        ! files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
-        ! is uniform in x, y and z.
-        ! This field can be used to model the traveling wave structure
+        !> read in discrete complex Ex(x,y,z), Ey(x,y,z), Ez(x,y,z), Bx(x,y,z), By(x,y,z),
+        !> Bz(x,y,z) rf data from
+        !> files "1Tx.T7 or 1Txx.T7 or 1Txxx.T7. Here, the grid
+        !> is uniform in x, y and z.
+        !> This field can be used to model the traveling wave structure
         subroutine read3t_Data(this,ifile)
         implicit none
         include 'mpif.h' 


### PR DESCRIPTION
For beamlines with wide energy spread, such as laser-driven accelerators, it is helpful to be able to base output on a smaller energy range.

This pull request adds extra options to the input file to set a flag to switch on the filtering and define the lower and upper bounds of the target energy range.
Then the distance travelled by the bunch is calculated based on the filtered range rather than the full range of particles.