### PR TITLE
CI: Make sure we apt-get update before installing packages.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install GFortran
-        run: sudo apt install gfortran make
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran make
 
       - name: Install MPI - ${{ matrix.mpi }}
         if: matrix.mpi != 'nompi'
-        run: sudo apt install lib${{ matrix.mpi }}-dev
+        run: |
+          sudo apt-get update
+          sudo apt install lib${{ matrix.mpi }}-dev
 
       - name: Build - No MPI
         if: matrix.mpi == 'nompi'
@@ -55,11 +59,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install GFortran
-        run: sudo apt install gfortran cmake
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran cmake
 
       - name: Install MPI - ${{ matrix.mpi }}
         if: matrix.mpi != 'nompi'
-        run: sudo apt install lib${{ matrix.mpi }}-dev
+        run: |
+          sudo apt-get update
+          sudo apt install lib${{ matrix.mpi }}-dev
 
       - name: Build - No MPI
         if: matrix.mpi == 'nompi'


### PR DESCRIPTION
This pull request solves an issue with the tests running on GitHub Actions which were failing to install MPI (OpenMPI and MPICH).

Attn. @ax3l 