### PR TITLE
CMake: Make CMAKE_BUILD_TYPE Overwritable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,10 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 # Uncomment for VERBOSE Makefiles. Useful for debugging.
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
-# Uncomment for Debug Build
-#set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_BUILD_TYPE Release)
+# Build type: typically Release, Debug or RelWithDebInfo
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
 
 # project name and language
 project(ImpactT LANGUAGES Fortran)


### PR DESCRIPTION
Make sure `CMAKE_BUILD_TYPE` can be overwitten from the command line with `-DCMAKE_BUILD_TYPE=Debug`, for instance.

Patch already in IMPACT-Z, now backported.

@hhslepicka @qianglbl 