### PR TITLE
Update Quadrupole.f90

### DIFF
--- a/src/Appl/Quadrupole.f90
+++ b/src/Appl/Quadrupole.f90
@@ -464,7 +464,7 @@
           !call getfldfrg_Quadrupole(zz,this,bgrad)
           call getfldfrgAna2_Quadrupole(zz,this,bgrad,bgradp,bgradpp)
         else if(this%Param(3).ge.100.0d0) then
-          call getfldfrgAna3_Quadrupole(zz,this,bgrad,bgradp,bgradpp,fldata)
+          call getfldfrgAna3_Quadrupole(pos(3),this,bgrad,bgradp,bgradpp,fldata)
         else
           bgrad = this%Param(2)
         endif


### PR DESCRIPTION
Corrected zz to pos(3) in getflderrt_Quadrupole, which prevented the soft edge quadrupole from working with error studies.