### PR TITLE
Fix Particle file output spacing for consistency and ease of parsing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
-        mpi: ['nompi', 'openmpi', 'mpich']
+        os: ["ubuntu-latest"]
+        mpi: ["nompi", "openmpi", "mpich"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
         if: matrix.mpi != 'nompi'
         run: |
           cd src/
-          make FC=mpifort LINK=mpifort USE_MPI=1
+          FFLAGS="$FFLAGS -fallow-argument-mismatch" make FC=mpifort LINK=mpifort USE_MPI=1
 
       - name: Test - No MPI
         if: matrix.mpi == 'nompi'
@@ -41,21 +41,29 @@ jobs:
           cd $GITHUB_WORKSPACE/examples/Sample1
           $GITHUB_WORKSPACE/src/ImpactTexe
 
-      - name: Test - MPI - ${{ matrix.mpi }}
-        if: matrix.mpi != 'nompi'
+      - name: Test - mpich
+        if: matrix.mpi == 'mpich'
+        run: |
+          cd $GITHUB_WORKSPACE/examples/Sample1
+          # NOTE: MPICH on GitHub Actions runners fail to allocate more than 1
+          # process for the communicator. We're only testing that the MPI
+          # executable doesn't fail outright here.
+          mpirun -n 1 $GITHUB_WORKSPACE/src/ImpactTexe-mpi
+
+      - name: Test - OpenMPI
+        if: matrix.mpi == 'openmpi'
         run: |
           cd $GITHUB_WORKSPACE/examples/Sample1
           sed -i"" '5s/1 1/2 1/' ImpactT.in
           mpirun -n 2 $GITHUB_WORKSPACE/src/ImpactTexe-mpi
-
 
   cmake:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        mpi: [ nompi, openmpi, mpich ]
+        os: [ubuntu-latest]
+        mpi: [nompi, openmpi, mpich]
     steps:
       - uses: actions/checkout@v2
       - name: Install GFortran
@@ -91,9 +99,30 @@ jobs:
           cd $GITHUB_WORKSPACE/examples/Sample1
           $GITHUB_WORKSPACE/build/ImpactTexe
 
-      - name: Test - MPI - ${{ matrix.mpi }}
-        if: matrix.mpi != 'nompi'
+      - name: Test - mpich
+        if: matrix.mpi == 'mpich'
+        run: |
+          cd $GITHUB_WORKSPACE/examples/Sample1
+          # NOTE: MPICH on GitHub Actions runners fail to allocate more than 1
+          # process for the communicator. We're only testing that the MPI
+          # executable doesn't fail outright here.
+          mpirun -n 1 $GITHUB_WORKSPACE/build/ImpactTexe-mpi
+
+      - name: Test - OpenMPI
+        if: matrix.mpi == 'openmpi'
         run: |
           cd $GITHUB_WORKSPACE/examples/Sample1
           sed -i"" '5s/1 1/2 1/' ImpactT.in
           mpirun -n 2 $GITHUB_WORKSPACE/build/ImpactTexe-mpi
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.mpi != 'nompi'
+        with:
+          name: ImpactT-${{ matrix.os }}-${{ matrix.mpi }}
+          path: build/ImpactTexe-mpi
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.mpi == 'nompi'
+        with:
+          name: ImpactT-${{ matrix.os }}-${{ matrix.mpi }}
+          path: build/ImpactTexe

--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ If you are new to CMake, [this short tutorial](https://hsf-training.github.io/hs
 
 If you just want to use CMake to build the project, jump into sections *1. Introduction*, *2. Building with CMake* and *9. Finding Packages*.
 
+## Using conda to compile IMPACT-T
+
+`conda-forge` has all of the necessary compilers and dependencies to build IMPACT-T from source.
+
+Create a build environment like so:
+
+```bash
+conda create -n impactt-build -c conda-forge compilers cmake openmpi
+conda activate impactt-build
+```
+
+Then to build the non-parallel version:
+
+```bash
+cmake -S src/ -B build-single
+cmake --build build-single -j 4
+ls build-single/ImpactTexe
+```
+
+And to build the MPI-parallelized version with OpenMPI:
+
+```bash
+cmake -S src/ -B build-mpi -DUSE_MPI=ON
+cmake --build build-mpi -j 4
+ls build-mpi/ImpactTexe-mpi
+```
+
 ## Unix
 
 ### Single Processor Code:

--- a/src/Contrl/Output.f90
+++ b/src/Contrl/Output.f90
@@ -2248,8 +2248,7 @@
                         MPI_COMM_WORLD,ierr)
         endif
 
-!100     format(6(1x,e17.9))
-100     format(9(1x,e20.12))
+100     format(9(g0,1x))
 
         deallocate(nptlist)
         deallocate(recvbuf)


### PR DESCRIPTION
## Changes

1. Fix leading/trailing spaces in particle file output
2. Add compilation documentation when using `conda-forge`'s compilers
3. Fix CI building/running

### Particle file output

This fixes the leading spaces in output particle files. This saves a bit of space and makes it slightly easier for not-so-smart parsers to read the output particles (specifically `polars.read_csv` on our end, which can be ~10x faster than `numpy.loadtxt` for large particle output files).

Currently particles look like this:
```
   0.192544220656E-03  -0.451056940538E-04   0.472496073462E-08   0.564525641813E-03  -0.107436741277E-05   0.115771507881E-02  -0.195692801440E-05  -0.000000000000E+00   0.100000000000E+01
```
After this PR, the leading space and double spaces between should be removed. `g0` formatting looks like the following:
```
0.19254422065579266E-3 -0.45105694053811659E-4 0.47249607346183573E-8 0.56452564181341889E-3 -0.10743674127672016E-5 0.11577150788125525E-2 -0.19569280144029904E-5 -0.0000000000000000 1.0000000000000000
```

Fortunately, there does not appear to be a trailing space inserted with `9(g0,1x)`.

### CI fix


* A necessary flag for the standard GNU `make` workflow to work with modern compilers wasn't being passed (`-fallow-argument-mismatch`)
* `MPICH` on GitHub Actions appears to have issues assigning the number of requested processors for the communicator
   * This made running the first example with 2+ cores impossible. (See notes below)
   * It would result in the error: `MPIR_Cart_create_impl(41): Size of the communicator (1) is smaller than the size of the Cartesian topology (2)`
   * I adjusted MPICH to only run 1x1 processes, to at least verify that the build worked.

(Similar to https://github.com/impact-lbl/IMPACT-Z/pull/12)